### PR TITLE
fix(cli): sync version with package metadata

### DIFF
--- a/src/mcp_server_python_docs/__init__.py
+++ b/src/mcp_server_python_docs/__init__.py
@@ -1,3 +1,17 @@
 """MCP server for Python standard library documentation."""
 
-__version__ = "0.1.0"
+import tomllib
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+
+def _read_version() -> str:
+    try:
+        return version("mcp-server-python-docs")
+    except PackageNotFoundError:
+        pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
+        with pyproject_path.open("rb") as fh:
+            return tomllib.load(fh)["project"]["version"]
+
+
+__version__ = _read_version()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,10 +5,12 @@ PKG-04 (synonyms.yaml in wheel), and PKG-06 (--version flag).
 """
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
 import zipfile
+from importlib.metadata import version
 from pathlib import Path
 
 import pytest
@@ -100,8 +102,37 @@ class TestPyprojectDeps:
 class TestVersionFlag:
     """PKG-06: --version flag prints version."""
 
+    def test_module_version_matches_package_metadata(self):
+        """__version__ stays in sync with installed package metadata."""
+        import mcp_server_python_docs
+
+        assert mcp_server_python_docs.__version__ == version("mcp-server-python-docs")
+
+    def test_source_tree_import_without_installed_metadata(self):
+        """Source-tree import falls back to pyproject.toml when metadata is absent."""
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-S",
+                "-c",
+                "import mcp_server_python_docs; print(mcp_server_python_docs.__version__)",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"Source-tree import failed.\n"
+            f"stdout: {result.stdout!r}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        assert result.stdout.strip() == version("mcp-server-python-docs")
+
     def test_version_flag_output(self):
-        """--version prints 0.1.0."""
+        """--version prints the installed package metadata version."""
         result = subprocess.run(
             [sys.executable, "-m", "mcp_server_python_docs", "--version"],
             capture_output=True,
@@ -110,8 +141,9 @@ class TestVersionFlag:
         )
         # Version output goes to stderr due to stdio hygiene
         combined = result.stdout + result.stderr
-        assert "0.1.0" in combined, (
-            f"Expected '0.1.0' in output.\n"
+        expected = version("mcp-server-python-docs")
+        assert expected in combined, (
+            f"Expected {expected!r} in output.\n"
             f"stdout: {result.stdout!r}\n"
             f"stderr: {result.stderr!r}"
         )
@@ -140,7 +172,7 @@ class TestInstallability:
         )
         assert result.returncode == 0
         combined = result.stdout + result.stderr
-        assert "0.1.0" in combined
+        assert version("mcp-server-python-docs") in combined
 
     def test_entry_point_module_exists(self):
         """The entry-point module is importable."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -108,7 +108,7 @@ class TestVersionFlag:
 
         assert mcp_server_python_docs.__version__ == version("mcp-server-python-docs")
 
-    def test_source_tree_import_without_installed_metadata(self):
+    def test_source_tree_import_without_installed_metadata(self, tmp_path: Path):
         """Source-tree import falls back to pyproject.toml when metadata is absent."""
         env = os.environ.copy()
         env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
@@ -123,6 +123,7 @@ class TestVersionFlag:
             text=True,
             timeout=10,
             env=env,
+            cwd=str(tmp_path),
         )
         assert result.returncode == 0, (
             f"Source-tree import failed.\n"


### PR DESCRIPTION
## Summary

- Read `mcp_server_python_docs.__version__` from installed package metadata.
- Update packaging tests so `--version` is checked against the metadata version instead of a hardcoded string.
- Add a regression test that keeps `__version__` synchronized with package metadata.

## Tests

- `git diff --check`
- `uv run ruff check src/ tests/`
- `uv run pyright src/`
- `uv run mcp-server-python-docs --version`
- `uv run pytest tests/test_packaging.py::TestVersionFlag tests/test_packaging.py::TestInstallability::test_module_runnable -q`
- `$env:PYTHONUTF8='1'; uv run pytest --tb=short -q`

Results:

- `mcp-server-python-docs --version` now prints `mcp-server-python-docs 0.1.1`.
- UTF-8 full suite: 264 passed, 1 skipped.

Local Windows note:

- Running `uv run pytest --tb=short -q` without `PYTHONUTF8=1` fails on this Windows shell because several existing `Path.read_text()` calls use the default GBK locale and hit UTF-8 bytes in repo files. With UTF-8 mode enabled, the same suite passes.

Closes #11.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Version resolution now derives dynamically from installed package metadata with a fallback to source metadata

* **Tests**
  * Enhanced version-related tests to validate module and CLI version output against distribution metadata across installed and source-tree import scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/21)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->