### PR TITLE
chore: prepare launch metadata and package rename

### DIFF
--- a/.github/INTEGRATION-TEST.md
+++ b/.github/INTEGRATION-TEST.md
@@ -13,9 +13,9 @@ Release-specific sign-off still lives in [`.github/RELEASE.md`](RELEASE.md).
   - `uv run pyright src/`
   - `uv run pytest --tb=short -q`
 - Local index build completed:
-  - `uv run mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14`
+  - `uv run python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14`
 - Doctor passes:
-  - `uv run mcp-server-python-docs doctor`
+  - `uv run python-docs-mcp-server doctor`
 - Slow E2E workflow passes when preparing a release:
   - GitHub Actions: `Slow E2E`
   - Expected: Python 3.13 and 3.14 jobs both complete `build-index`, `doctor`,
@@ -29,7 +29,7 @@ Use Inspector for fast local iteration before checking real clients.
 ### Start Inspector
 
 ```bash
-npx @modelcontextprotocol/inspector uv --directory . run mcp-server-python-docs
+npx @modelcontextprotocol/inspector uv --directory . run python-docs-mcp-server
 ```
 
 ### Verify
@@ -62,7 +62,7 @@ npx @modelcontextprotocol/inspector uv --directory . run mcp-server-python-docs
   "mcpServers": {
     "python-docs": {
       "command": "uvx",
-      "args": ["mcp-server-python-docs"]
+      "args": ["python-docs-mcp-server"]
     }
   }
 }
@@ -90,7 +90,7 @@ npx @modelcontextprotocol/inspector uv --directory . run mcp-server-python-docs
 2. Add a server:
    - Name: `python-docs`
    - Command: `uvx`
-   - Args: `mcp-server-python-docs`
+   - Args: `python-docs-mcp-server`
 3. Confirm the server shows as connected
 
 ### Checks
@@ -111,11 +111,11 @@ locked.
 
 ### Checks
 
-- [ ] `uvx mcp-server-python-docs --version`
+- [ ] `uvx python-docs-mcp-server --version`
   - Expected: prints the current package version
-- [ ] `uvx mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14`
+- [ ] `uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14`
   - Expected: index build completes successfully
-- [ ] `uvx mcp-server-python-docs doctor`
+- [ ] `uvx python-docs-mcp-server doctor`
   - Expected: all required checks pass
 - [ ] Follow the README from scratch
   - Expected: a new user can get to a working client configuration without using `.planning/`
@@ -130,7 +130,7 @@ or supported Python versions.
 - [ ] Start the `Slow E2E` workflow from GitHub Actions
   - Expected: both Python 3.13 and Python 3.14 jobs start
 - [ ] Confirm each job installs the built wheel into a clean virtual environment
-  - Expected: the command path is the installed `mcp-server-python-docs`, not editable source
+  - Expected: the command path is the installed `python-docs-mcp-server`, not editable source
 - [ ] Confirm `build-index --versions 3.10,3.11,3.12,3.13,3.14` passes
   - Expected: all five versions produce content, not symbol-only fallback
 - [ ] Confirm `doctor` and `validate-corpus` pass

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -41,20 +41,20 @@ versions 3.10 through 3.14.
 2. Verify the version in `pyproject.toml` is correct:
    ```bash
    grep '^version' pyproject.toml
-   # Should show: version = "0.1.0"
+   # Should show: version = "0.1.1"
    ```
 
 3. Create and push the tag:
    ```bash
-   git tag -a v0.1.0 -m "Release v0.1.0"
-   git push origin v0.1.0
+   git tag -a v0.1.1 -m "Release v0.1.1"
+   git push origin v0.1.1
    ```
 
 4. Monitor the release workflow at:
    https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
 
 5. Verify the package on PyPI:
-   https://pypi.org/project/mcp-server-python-docs/0.1.0/
+   https://pypi.org/project/mcp-server-python-docs/0.1.1/
 
 ## Post-Release Verification
 
@@ -63,14 +63,14 @@ After the package is published:
 ```bash
 # In a fresh environment:
 uvx mcp-server-python-docs --version
-# Should print: 0.1.0
+# Should print: 0.1.1
 
 # Or via pipx:
 pipx run mcp-server-python-docs --version
-# Should print: 0.1.0
+# Should print: 0.1.1
 ```
 
-## v0.1.0 Release Checklist
+## v0.1.1 Release Checklist
 
 Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 
@@ -81,7 +81,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   ```bash
   uv run pytest --tb=short -q
   ```
-- [ ] Version in `pyproject.toml` is `0.1.0`:
+- [ ] Version in `pyproject.toml` is `0.1.1`:
   ```bash
   grep '^version' pyproject.toml
   ```
@@ -105,7 +105,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 
 - [ ] Create the annotated tag:
   ```bash
-  git tag -a v0.1.0 -m "Release v0.1.0
+  git tag -a v0.1.1 -m "Release v0.1.1
 
   First public release of mcp-server-python-docs.
 
@@ -116,14 +116,14 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   ```
 - [ ] Push the tag to trigger the release workflow:
   ```bash
-  git push origin v0.1.0
+  git push origin v0.1.1
   ```
 - [ ] Monitor the workflow run: https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
 - [ ] Verify all three jobs pass: `build` -> `publish` -> `github-release`
 
 ### Post-Release Verification (SHIP-06)
 
-- [ ] Package visible on PyPI: https://pypi.org/project/mcp-server-python-docs/0.1.0/
+- [ ] Package visible on PyPI: https://pypi.org/project/mcp-server-python-docs/0.1.1/
 - [ ] Attestation visible on PyPI package page (look for "Provenance" badge)
 - [ ] Fresh install test:
   ```bash
@@ -132,13 +132,13 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 
   # Install and verify version
   uvx mcp-server-python-docs --version
-  # Expected output: 0.1.0
+  # Expected output: 0.1.1
   ```
 - [ ] Full README flow test (from a clean environment):
   ```bash
   # Step 1: Install
   uvx mcp-server-python-docs --version
-  # Should print 0.1.0
+  # Should print 0.1.1
 
   # Step 2: Build index
   uvx mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
@@ -161,10 +161,10 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 ### Release Complete
 
 - [ ] GitHub Release exists with attached artifacts
-- [ ] PyPI page shows 0.1.0 with attestation
+- [ ] PyPI page shows 0.1.1 with attestation
 - [ ] README install instructions verified end-to-end
 - [ ] Slow E2E workflow passed for the release candidate
-- [ ] Tag v0.1.0 exists in git
+- [ ] Tag v0.1.1 exists in git
 
 **Release date**: _______________
 **Released by**: _______________

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -6,7 +6,7 @@ Before the first release, configure PyPI Trusted Publishing:
 
 1. Go to https://pypi.org/manage/account/publishing/
 2. Add a new pending publisher:
-   - **PyPI project name**: `mcp-server-python-docs`
+   - **PyPI project name**: `python-docs-mcp-server`
    - **Owner**: your GitHub username or org
    - **Repository**: `python-docs-mcp-server`
    - **Workflow name**: `release.yml`
@@ -54,7 +54,7 @@ versions 3.10 through 3.14.
    https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
 
 5. Verify the package on PyPI:
-   https://pypi.org/project/mcp-server-python-docs/0.1.1/
+   https://pypi.org/project/python-docs-mcp-server/0.1.1/
 
 ## Post-Release Verification
 
@@ -62,11 +62,11 @@ After the package is published:
 
 ```bash
 # In a fresh environment:
-uvx mcp-server-python-docs --version
+uvx python-docs-mcp-server --version
 # Should print: 0.1.1
 
 # Or via pipx:
-pipx run mcp-server-python-docs --version
+pipx run python-docs-mcp-server --version
 # Should print: 0.1.1
 ```
 
@@ -88,13 +88,13 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 - [ ] Integration tests from `.github/INTEGRATION-TEST.md` are complete and signed off
 - [ ] Doctor subcommand passes:
   ```bash
-  mcp-server-python-docs doctor
+  uv run python-docs-mcp-server doctor
   ```
 
 ### PyPI Trusted Publishing Setup (one-time)
 
 - [ ] PyPI pending publisher configured at https://pypi.org/manage/account/publishing/:
-  - PyPI project name: `mcp-server-python-docs`
+  - PyPI project name: `python-docs-mcp-server`
   - Owner: `<your-github-username>`
   - Repository: `python-docs-mcp-server`
   - Workflow name: `release.yml`
@@ -107,12 +107,12 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   ```bash
   git tag -a v0.1.1 -m "Release v0.1.1
 
-  First public release of mcp-server-python-docs.
+  First public release of python-docs-mcp-server.
 
   A read-only, version-aware MCP retrieval server over Python
   standard library documentation (3.10 through 3.14).
 
-  Installable via: uvx mcp-server-python-docs"
+  Installable via: uvx python-docs-mcp-server"
   ```
 - [ ] Push the tag to trigger the release workflow:
   ```bash
@@ -123,29 +123,29 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 
 ### Post-Release Verification (SHIP-06)
 
-- [ ] Package visible on PyPI: https://pypi.org/project/mcp-server-python-docs/0.1.1/
+- [ ] Package visible on PyPI: https://pypi.org/project/python-docs-mcp-server/0.1.1/
 - [ ] Attestation visible on PyPI package page (look for "Provenance" badge)
 - [ ] Fresh install test:
   ```bash
   # Clear any cached version
-  uv cache clean mcp-server-python-docs 2>/dev/null || true
+  uv cache clean python-docs-mcp-server 2>/dev/null || true
 
   # Install and verify version
-  uvx mcp-server-python-docs --version
+  uvx python-docs-mcp-server --version
   # Expected output: 0.1.1
   ```
 - [ ] Full README flow test (from a clean environment):
   ```bash
   # Step 1: Install
-  uvx mcp-server-python-docs --version
+  uvx python-docs-mcp-server --version
   # Should print 0.1.1
 
   # Step 2: Build index
-  uvx mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
+  uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
   # Should complete successfully
 
   # Step 3: Doctor check
-  uvx mcp-server-python-docs doctor
+  uvx python-docs-mcp-server doctor
   # All checks should PASS
   ```
 - [ ] Slow E2E workflow passes:
@@ -154,8 +154,36 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   - Confirm each job installs the built wheel, runs
     `build-index --versions 3.10,3.11,3.12,3.13,3.14`, `doctor`, and
     `validate-corpus`
+
+### Post-PyPI Launch Pack Cleanup
+
+- [ ] Remove every temporary PyPI pre-release block from `README.md`:
+  - Delete each `<!-- PRE-PYPI: ... -->` through `<!-- /PRE-PYPI -->` region,
+    including the marker comments and GitHub-source replacement commands
+  - Remove or rewrite stale "Before PyPI publishing" headings, "Until the first
+    PyPI release is published" text, and "After PyPI publishing" qualifiers
+  - Make the published package commands (`uvx python-docs-mcp-server ...`) the
+    primary install, build-index, MCP client, `doctor`, and `validate-corpus`
+    examples
+- [ ] Verify `README.md` has no temporary pre-release install artifacts:
+  ```bash
+  rg -n 'PRE[-]PYPI|Before PyPI publishing|Until the first PyPI|After PyPI publishing|git\\+https://github.com/.*/python-docs-mcp-server' README.md
+  ```
+  The command should return no output.
+- [ ] Review `docs/launch/` so no public launch copy still asks users to install
+  from GitHub source after the PyPI package is available. Intentional historical
+  pre-release drafts may remain, but they must stay clearly labeled as
+  pre-PyPI-only.
+- [ ] Submit `server.json` to https://registry.modelcontextprotocol.io/ via the
+  `mcp-publisher` CLI after the PyPI smoke test passes; verify the registry
+  listing appears and points at version 0.1.1
+- [ ] Use the post-PyPI draft in `docs/launch/show-hn.md` for the HN submission
+- [ ] Use `docs/launch/reddit-posts.md` for the r/Python and r/LocalLLaMA
+  submissions after the PyPI release smoke test passes
+- [ ] Commit and push the README cleanup before public launch posts go out
+
 - [ ] Claude Desktop test with published package:
-  Configure `mcpServers` with `uvx mcp-server-python-docs` and verify
+  Configure `mcpServers` with `uvx python-docs-mcp-server` and verify
   "what is asyncio.TaskGroup" returns a correct hit
 
 ### Release Complete
@@ -163,6 +191,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 - [ ] GitHub Release exists with attached artifacts
 - [ ] PyPI page shows 0.1.1 with attestation
 - [ ] README install instructions verified end-to-end
+- [ ] README no longer contains temporary pre-PyPI GitHub-source install blocks
 - [ ] Slow E2E workflow passed for the release candidate
 - [ ] Tag v0.1.1 exists in git
 

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -158,10 +158,9 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 ### Post-PyPI Launch Pack Cleanup
 
 - [ ] Remove every temporary PyPI pre-release block from `README.md`:
-  - Delete each `<!-- PRE-PYPI: ... -->` through `<!-- /PRE-PYPI -->` region,
-    including the marker comments and GitHub-source replacement commands
-  - Remove or rewrite stale "Before PyPI publishing" headings, "Until the first
-    PyPI release is published" text, and "After PyPI publishing" qualifiers
+  - Mechanical pass: delete every region from `<!-- PRE-PYPI:` to `<!-- /PRE-PYPI -->` (inclusive). Each block now encloses its surrounding heading + lead-in sentence + code, so a single pass produces a clean README.
+  - Reference command:
+    `perl -0777 -i -pe 's/<!-- PRE-PYPI:.*?<!-- \/PRE-PYPI -->\n*//gs' README.md`
   - Make the published package commands (`uvx python-docs-mcp-server ...`) the
     primary install, build-index, MCP client, `doctor`, and `validate-corpus`
     examples

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,7 +33,7 @@ jobs:
           uv run --python ${{ matrix.python-version }} python -m venv .e2e-venv
           .e2e-venv/bin/python -m pip install --upgrade pip
           .e2e-venv/bin/python -m pip install dist/*.whl
-          .e2e-venv/bin/mcp-server-python-docs --version
+          .e2e-venv/bin/python-docs-mcp-server --version
 
       - name: Build and validate full docs index
         env:
@@ -41,10 +41,10 @@ jobs:
           XDG_CACHE_HOME: ${{ runner.temp }}/mcp-python-docs-cache
         run: |
           set -o pipefail
-          .e2e-venv/bin/mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14 \
+          .e2e-venv/bin/python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14 \
             2>&1 | tee "${RUNNER_TEMP}/build-index-${{ matrix.python-version }}.log"
-          .e2e-venv/bin/mcp-server-python-docs doctor
-          .e2e-venv/bin/mcp-server-python-docs validate-corpus
+          .e2e-venv/bin/python-docs-mcp-server doctor
+          .e2e-venv/bin/python-docs-mcp-server validate-corpus
 
       - name: Upload E2E logs and cache artifacts
         if: always()

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-`mcp-server-python-docs` is a read-only MCP server for the official Python
+`python-docs-mcp-server` is a read-only MCP server for the official Python
 standard library documentation. It is built for end users who want precise,
 version-aware stdlib answers inside MCP clients such as Claude, Cursor, and
 Codex without relying on an external hosted docs API at query time.
@@ -39,9 +39,9 @@ uv run pytest --tb=short -q
 Build and inspect a local docs index:
 
 ```bash
-uv run mcp-server-python-docs build-index --versions 3.12,3.13
-uv run mcp-server-python-docs doctor
-uv run mcp-server-python-docs validate-corpus
+uv run python-docs-mcp-server build-index --versions 3.12,3.13
+uv run python-docs-mcp-server doctor
+uv run python-docs-mcp-server validate-corpus
 ```
 
 Package smoke check:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to mcp-server-python-docs
+# Contributing to python-docs-mcp-server
 
 Start here for current contributor workflow. You should not need `.planning/`
 to set up, test, or validate the repo.
@@ -42,9 +42,9 @@ uv run pytest tests/test_retrieval_regression.py -q
 The server needs a local SQLite index before runtime validation:
 
 ```bash
-uv run mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
-uv run mcp-server-python-docs doctor
-uv run mcp-server-python-docs validate-corpus
+uv run python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+uv run python-docs-mcp-server doctor
+uv run python-docs-mcp-server validate-corpus
 ```
 
 `build-index` downloads the symbol inventories, clones CPython docs sources,

--- a/README.md
+++ b/README.md
@@ -395,6 +395,31 @@ Adjust `3.12` to match the version shown by `doctor`. Without this package,
 `build-index` cannot create the disposable Sphinx environment it uses to build
 JSON documentation content.
 
+### Migrating from the pre-rename CLI
+
+Earlier development snapshots of this project used the PyPI name
+`mcp-server-python-docs`. The published PyPI project is
+`python-docs-mcp-server`. If your MCP client config still references
+the old name via `uvx`, you will see a `Package not found` error,
+because `uvx` resolves projects by PyPI name.
+
+Update your config's `args` from:
+
+```json
+"args": ["mcp-server-python-docs"]
+```
+
+to:
+
+```json
+"args": ["python-docs-mcp-server"]
+```
+
+The wheel still installs a legacy `mcp-server-python-docs` console
+script for users who already have the package installed and invoke
+the binary by name on `$PATH`. That script is an alias and will be
+removed in a future release.
+
 ### `uvx` cache stale
 
 If `uvx python-docs-mcp-server` runs an old version:

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ matching section. Instead of generic web results or an entire docs page, it gets
 the official stdlib text for the requested Python version, trimmed to the useful
 section.
 
+<!-- PRE-PYPI: replace this temporary GitHub-source smoke test after the first PyPI publish -->
 Local source smoke test until the PyPI package is published:
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
@@ -81,17 +81,19 @@ uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-d
 
 ## Install
 
+<!-- PRE-PYPI: remove this entire "Before PyPI publishing" block (heading + prose + code) after the first PyPI publish -->
 ### Before PyPI publishing (install from GitHub source)
 
 Until the first PyPI release is published, run from GitHub:
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
+<!-- PRE-PYPI: after the first PyPI publish, drop this "After PyPI publishing" heading so the section reads simply as "## Install" -->
 ### After PyPI publishing
+<!-- /PRE-PYPI -->
 
 Run directly with `uvx`:
 
@@ -114,13 +116,17 @@ shell or use `python -m uv ...` as a fallback for local contributor commands.
 
 Build the local documentation index:
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+<!-- PRE-PYPI: remove the GitHub-source build-index command and the "After PyPI publishing" lead-in after the first PyPI publish; the post-PyPI code fence below survives -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
-<!-- /PRE-PYPI -->
 
 After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
+<!-- /PRE-PYPI -->
+
+```bash
+uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+```
 
 If you installed the package persistently, you can drop the `uvx` prefix:
 
@@ -144,7 +150,7 @@ Add this to your Claude Desktop configuration file:
 
 **Windows:** `%APPDATA%\\Claude\\claude_desktop_config.json`
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+<!-- PRE-PYPI: remove the GitHub-source config and the "After PyPI publishing, use:" lead-in after the first PyPI publish; the post-PyPI config fence below survives -->
 ```json
 {
   "mcpServers": {
@@ -159,9 +165,9 @@ Add this to your Claude Desktop configuration file:
   }
 }
 ```
-<!-- /PRE-PYPI -->
 
 After PyPI publishing, use:
+<!-- /PRE-PYPI -->
 
 ```json
 {
@@ -181,7 +187,7 @@ Restart Claude Desktop after editing the config file.
 Add this to your Cursor MCP settings (`.cursor/mcp.json` in your project or
 global settings):
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+<!-- PRE-PYPI: remove the GitHub-source config and the "After PyPI publishing, use:" lead-in after the first PyPI publish; the post-PyPI config fence below survives -->
 ```json
 {
   "mcpServers": {
@@ -196,9 +202,9 @@ global settings):
   }
 }
 ```
-<!-- /PRE-PYPI -->
 
 After PyPI publishing, use:
+<!-- /PRE-PYPI -->
 
 ```json
 {
@@ -215,15 +221,15 @@ After PyPI publishing, use:
 
 Add this to `.codex/config.toml`:
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+<!-- PRE-PYPI: remove the GitHub-source config and the "After PyPI publishing, use:" lead-in after the first PyPI publish; the post-PyPI config fence below survives -->
 ```toml
 [mcp_servers.python-docs]
 command = "uvx"
 args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "python-docs-mcp-server"]
 ```
-<!-- /PRE-PYPI -->
 
 After PyPI publishing, use:
+<!-- /PRE-PYPI -->
 
 ```toml
 [mcp_servers.python-docs]
@@ -313,15 +319,15 @@ search, or silently fall back to unofficial community mirrors.
 
 ## Diagnostics
 
+<!-- PRE-PYPI: remove the GitHub-source doctor invocation and "After PyPI publishing:" lead-in after the first PyPI publish; the post-PyPI code fence below survives -->
 Before PyPI publishing, run `doctor` from the GitHub source package:
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server doctor
 ```
-<!-- /PRE-PYPI -->
 
 After PyPI publishing:
+<!-- /PRE-PYPI -->
 
 ```bash
 uvx python-docs-mcp-server doctor
@@ -331,16 +337,16 @@ This checks the runtime Python version, SQLite FTS5, cache/index paths, disk
 space, and whether the current interpreter has the `venv`/`ensurepip` support
 needed by `build-index`.
 
+<!-- PRE-PYPI: remove the GitHub-source validate-corpus invocation and "After PyPI publishing:" lead-in after the first PyPI publish; the post-PyPI code fence below survives -->
 Before PyPI publishing, validate an existing index from the GitHub source
 package:
 
-<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server validate-corpus
 ```
-<!-- /PRE-PYPI -->
 
 After PyPI publishing:
+<!-- /PRE-PYPI -->
 
 ```bash
 uvx python-docs-mcp-server validate-corpus

--- a/README.md
+++ b/README.md
@@ -58,9 +58,33 @@ exposes a small MCP tool surface tuned for high-signal retrieval.
 The model gets the exact symbol match and the relevant documentation section
 instead of a full-page dump.
 
+## 30-second demo
+
+Ask your MCP client:
+
+> In Python 3.13, how should I use `asyncio.TaskGroup` and what changed from older asyncio patterns?
+
+The agent should use `search_docs` for the exact symbol, then `get_docs` for the
+matching section. Instead of generic web results or an entire docs page, it gets
+the official stdlib text for the requested Python version, trimmed to the useful
+section.
+
+Local source smoke test until the PyPI package is published:
+
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+```
+
 ## Install
 
-Run it directly with `uvx`:
+Until the first PyPI release is published, run from GitHub:
+
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+```
+
+After PyPI publishing is complete, the package will also run directly with
+`uvx`:
 
 ```bash
 uvx mcp-server-python-docs --version
@@ -80,8 +104,10 @@ shell or use `python -m uv ...` as a fallback for local contributor commands.
 Build the local documentation index:
 
 ```bash
-uvx mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
+
+After PyPI publishing, `uvx mcp-server-python-docs build-index ...` is enough.
 
 If you installed the package persistently, you can drop the `uvx` prefix:
 
@@ -110,7 +136,11 @@ Add this to your Claude Desktop configuration file:
   "mcpServers": {
     "python-docs": {
       "command": "uvx",
-      "args": ["mcp-server-python-docs"]
+      "args": [
+        "--from",
+        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
+        "mcp-server-python-docs"
+      ]
     }
   }
 }
@@ -128,7 +158,11 @@ global settings):
   "mcpServers": {
     "python-docs": {
       "command": "uvx",
-      "args": ["mcp-server-python-docs"]
+      "args": [
+        "--from",
+        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
+        "mcp-server-python-docs"
+      ]
     }
   }
 }
@@ -141,7 +175,7 @@ Add this to `.codex/config.toml`:
 ```toml
 [mcp_servers.python-docs]
 command = "uvx"
-args = ["mcp-server-python-docs"]
+args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "mcp-server-python-docs"]
 ```
 
 ## How quality is verified
@@ -174,20 +208,21 @@ The server currently exposes five MCP tools:
 | `list_versions` | List all indexed Python versions with metadata. |
 | `detect_python_version` | Detect the user's local Python version and report whether it matches an indexed documentation version. |
 
-## When to use this instead of generic docs retrieval
+## Why not Context7 or generic docs retrieval?
 
-Use this server when you need:
+Use this server when the question is about Python's standard library and you
+want the boring answer that is actually correct:
 
-- exact Python stdlib symbol resolution
-- consistent version-aware answers across Python 3.10 through 3.14
-- token-efficient section retrieval from official docs
-- a local, read-only MCP server with a simple operational story
+- official Python docs, not scraped mirrors or mixed-source summaries
+- exact symbol resolution from `objects.inv`
+- Python-version-aware results across 3.10 through 3.14
+- token-efficient section retrieval instead of full-page dumps
+- local, read-only runtime behavior with no API keys
 
-Use a generic fetcher or broader docs MCP when you need:
-
-- arbitrary third-party package content beyond package-declared PyPI metadata
-- arbitrary web pages
-- mixed-source research across many frameworks
+Use Context7 or a generic docs fetcher when you need broader third-party library
+coverage, arbitrary web pages, or cross-framework research. This server is not a
+universal docs search engine. It is a precise stdlib retrieval tool for AI
+coding agents.
 
 ## Retrieved docs cache
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,25 @@ uv cache clean python-docs-mcp-server
 The MSIX-packaged version of Claude Desktop on Windows may have restricted PATH
 access. If `uvx` is not found, specify the full path in your config:
 
+<!-- PRE-PYPI: remove the GitHub-source config and the "After PyPI publishing, use:" lead-in after the first PyPI publish; the post-PyPI config fence below survives -->
+```json
+{
+  "mcpServers": {
+    "python-docs": {
+      "command": "C:\\Users\\YOU\\.local\\bin\\uvx.exe",
+      "args": [
+        "--from",
+        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
+        "python-docs-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+After PyPI publishing, use:
+<!-- /PRE-PYPI -->
+
 ```json
 {
   "mcpServers": {

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-d
 After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
 <!-- /PRE-PYPI -->
 
+<!-- PRE-PYPI: after the first PyPI publish, drop this "After PyPI publishing" heading so the section reads simply as "## First run" -->
+### After PyPI publishing
+<!-- /PRE-PYPI -->
+
 ```bash
 uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
@@ -329,6 +333,8 @@ uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-d
 After PyPI publishing:
 <!-- /PRE-PYPI -->
 
+Check the local environment:
+
 ```bash
 uvx python-docs-mcp-server doctor
 ```
@@ -347,6 +353,8 @@ uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-d
 
 After PyPI publishing:
 <!-- /PRE-PYPI -->
+
+Validate an existing index:
 
 ```bash
 uvx python-docs-mcp-server validate-corpus

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mcp-server-python-docs
+# python-docs-mcp-server
 
 <!-- mcp-name: io.github.ayhammouda/python-docs-mcp-server -->
 
@@ -75,32 +75,37 @@ Local source smoke test until the PyPI package is published:
 
 <!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
 ## Install
 
+### Before PyPI publishing (install from GitHub source)
+
 Until the first PyPI release is published, run from GitHub:
 
 <!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
-After PyPI publishing is complete, the package will also run directly with
-`uvx`:
+### After PyPI publishing
+
+Run directly with `uvx`:
 
 ```bash
-uvx mcp-server-python-docs --version
+uvx python-docs-mcp-server --version
 ```
 
 Or install it persistently:
 
 ```bash
-pipx install mcp-server-python-docs
+pipx install python-docs-mcp-server
 ```
+
+---
 
 If `uv` is installed but the `uv` command is not on your `PATH`, reopen your
 shell or use `python -m uv ...` as a fallback for local contributor commands.
@@ -111,16 +116,16 @@ Build the local documentation index:
 
 <!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
 <!-- /PRE-PYPI -->
 
-After PyPI publishing, `uvx mcp-server-python-docs build-index ...` is enough.
+After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
 
 If you installed the package persistently, you can drop the `uvx` prefix:
 
 ```bash
-mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
+python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
 
 This downloads Python's `objects.inv` files, clones CPython docs sources, runs
@@ -148,13 +153,26 @@ Add this to your Claude Desktop configuration file:
       "args": [
         "--from",
         "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
-        "mcp-server-python-docs"
+        "python-docs-mcp-server"
       ]
     }
   }
 }
 ```
 <!-- /PRE-PYPI -->
+
+After PyPI publishing, use:
+
+```json
+{
+  "mcpServers": {
+    "python-docs": {
+      "command": "uvx",
+      "args": ["python-docs-mcp-server"]
+    }
+  }
+}
+```
 
 Restart Claude Desktop after editing the config file.
 
@@ -172,13 +190,26 @@ global settings):
       "args": [
         "--from",
         "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
-        "mcp-server-python-docs"
+        "python-docs-mcp-server"
       ]
     }
   }
 }
 ```
 <!-- /PRE-PYPI -->
+
+After PyPI publishing, use:
+
+```json
+{
+  "mcpServers": {
+    "python-docs": {
+      "command": "uvx",
+      "args": ["python-docs-mcp-server"]
+    }
+  }
+}
+```
 
 ### Codex
 
@@ -188,9 +219,17 @@ Add this to `.codex/config.toml`:
 ```toml
 [mcp_servers.python-docs]
 command = "uvx"
-args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "mcp-server-python-docs"]
+args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "python-docs-mcp-server"]
 ```
 <!-- /PRE-PYPI -->
+
+After PyPI publishing, use:
+
+```toml
+[mcp_servers.python-docs]
+command = "uvx"
+args = ["python-docs-mcp-server"]
+```
 
 ## How quality is verified
 
@@ -224,13 +263,15 @@ The server currently exposes five MCP tools:
 
 ## Why not Context7 or generic docs retrieval?
 
-Use this server when the question is about Python's standard library and you
-want the boring answer that is actually correct:
+Use this server when you want precise local Python docs retrieval rather than
+broad web search:
 
 - official Python docs, not scraped mirrors or mixed-source summaries
 - exact symbol resolution from `objects.inv`
 - Python-version-aware results across 3.10 through 3.14
 - token-efficient section retrieval instead of full-page dumps
+- package-declared PyPI metadata lookup via `lookup_package_docs` for
+  documentation, homepage, and source URLs
 - local, read-only runtime behavior with no API keys
 
 Use Context7 or a generic docs fetcher when you need broader third-party library
@@ -276,34 +317,33 @@ Before PyPI publishing, run `doctor` from the GitHub source package:
 
 <!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs doctor
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server doctor
 ```
 <!-- /PRE-PYPI -->
 
 After PyPI publishing:
 
 ```bash
-uvx mcp-server-python-docs doctor
+uvx python-docs-mcp-server doctor
 ```
 
 This checks the runtime Python version, SQLite FTS5, cache/index paths, disk
 space, and whether the current interpreter has the `venv`/`ensurepip` support
 needed by `build-index`.
 
-Validate an existing index.
-
-Before PyPI publishing:
+Before PyPI publishing, validate an existing index from the GitHub source
+package:
 
 <!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs validate-corpus
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server validate-corpus
 ```
 <!-- /PRE-PYPI -->
 
 After PyPI publishing:
 
 ```bash
-uvx mcp-server-python-docs validate-corpus
+uvx python-docs-mcp-server validate-corpus
 ```
 
 ## Troubleshooting
@@ -314,11 +354,10 @@ If you see an error about SQLite FTS5 not being available:
 
 **Linux x86-64**
 
-After PyPI publishing, Linux x86-64 users can install the optional bundled
-SQLite package:
+Linux x86-64 users can install the optional bundled SQLite package:
 
 ```bash
-pip install 'mcp-server-python-docs[pysqlite3]'
+pip install 'python-docs-mcp-server[pysqlite3]'
 ```
 
 **macOS / Windows / Linux ARM**
@@ -344,16 +383,16 @@ JSON documentation content.
 
 ### `uvx` cache stale
 
-After PyPI publishing, if `uvx mcp-server-python-docs` runs an old version:
+If `uvx python-docs-mcp-server` runs an old version:
 
 ```bash
-uvx --reinstall mcp-server-python-docs
+uvx --reinstall python-docs-mcp-server
 ```
 
 Or clear the uv cache:
 
 ```bash
-uv cache clean mcp-server-python-docs
+uv cache clean python-docs-mcp-server
 ```
 
 ### Claude Desktop on Windows (MSIX)
@@ -366,7 +405,7 @@ access. If `uvx` is not found, specify the full path in your config:
   "mcpServers": {
     "python-docs": {
       "command": "C:\\Users\\YOU\\.local\\bin\\uvx.exe",
-      "args": ["mcp-server-python-docs"]
+      "args": ["python-docs-mcp-server"]
     }
   }
 }
@@ -395,10 +434,8 @@ For contributor setup and verification:
 Tested on macOS and Linux. Windows should work, but it is not verified on
 every release.
 
-Python documentation versions 3.10 through 3.14 are currently supported.
-
-The server requires Python 3.12+ to run. Its generated documentation corpus can
-still index Python documentation versions 3.10 through 3.14.
+The server requires Python 3.12+ to run. Its generated documentation corpus
+covers Python documentation versions 3.10 through 3.14.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mcp-server-python-docs
 
+<!-- mcp-name: io.github.ayhammouda/python-docs-mcp-server -->
+
 [![CI](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
@@ -71,17 +73,21 @@ section.
 
 Local source smoke test until the PyPI package is published:
 
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
 ```
+<!-- /PRE-PYPI -->
 
 ## Install
 
 Until the first PyPI release is published, run from GitHub:
 
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
 ```
+<!-- /PRE-PYPI -->
 
 After PyPI publishing is complete, the package will also run directly with
 `uvx`:
@@ -103,9 +109,11 @@ shell or use `python -m uv ...` as a fallback for local contributor commands.
 
 Build the local documentation index:
 
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
+<!-- /PRE-PYPI -->
 
 After PyPI publishing, `uvx mcp-server-python-docs build-index ...` is enough.
 
@@ -131,6 +139,7 @@ Add this to your Claude Desktop configuration file:
 
 **Windows:** `%APPDATA%\\Claude\\claude_desktop_config.json`
 
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```json
 {
   "mcpServers": {
@@ -145,6 +154,7 @@ Add this to your Claude Desktop configuration file:
   }
 }
 ```
+<!-- /PRE-PYPI -->
 
 Restart Claude Desktop after editing the config file.
 
@@ -153,6 +163,7 @@ Restart Claude Desktop after editing the config file.
 Add this to your Cursor MCP settings (`.cursor/mcp.json` in your project or
 global settings):
 
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```json
 {
   "mcpServers": {
@@ -167,16 +178,19 @@ global settings):
   }
 }
 ```
+<!-- /PRE-PYPI -->
 
 ### Codex
 
 Add this to `.codex/config.toml`:
 
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
 ```toml
 [mcp_servers.python-docs]
 command = "uvx"
 args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "mcp-server-python-docs"]
 ```
+<!-- /PRE-PYPI -->
 
 ## How quality is verified
 
@@ -258,7 +272,15 @@ search, or silently fall back to unofficial community mirrors.
 
 ## Diagnostics
 
-Check the local environment:
+Before PyPI publishing, run `doctor` from the GitHub source package:
+
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs doctor
+```
+<!-- /PRE-PYPI -->
+
+After PyPI publishing:
 
 ```bash
 uvx mcp-server-python-docs doctor
@@ -268,7 +290,17 @@ This checks the runtime Python version, SQLite FTS5, cache/index paths, disk
 space, and whether the current interpreter has the `venv`/`ensurepip` support
 needed by `build-index`.
 
-Validate an existing index:
+Validate an existing index.
+
+Before PyPI publishing:
+
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs validate-corpus
+```
+<!-- /PRE-PYPI -->
+
+After PyPI publishing:
 
 ```bash
 uvx mcp-server-python-docs validate-corpus
@@ -281,6 +313,9 @@ uvx mcp-server-python-docs validate-corpus
 If you see an error about SQLite FTS5 not being available:
 
 **Linux x86-64**
+
+After PyPI publishing, Linux x86-64 users can install the optional bundled
+SQLite package:
 
 ```bash
 pip install 'mcp-server-python-docs[pysqlite3]'
@@ -309,7 +344,7 @@ JSON documentation content.
 
 ### `uvx` cache stale
 
-If `uvx mcp-server-python-docs` runs an old version:
+After PyPI publishing, if `uvx mcp-server-python-docs` runs an old version:
 
 ```bash
 uvx --reinstall mcp-server-python-docs
@@ -361,6 +396,9 @@ Tested on macOS and Linux. Windows should work, but it is not verified on
 every release.
 
 Python documentation versions 3.10 through 3.14 are currently supported.
+
+The server requires Python 3.12+ to run. Its generated documentation corpus can
+still index Python documentation versions 3.10 through 3.14.
 
 ## License
 

--- a/docs/launch/reddit-posts.md
+++ b/docs/launch/reddit-posts.md
@@ -72,3 +72,39 @@ uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-d
 
 I'd appreciate practical feedback from people wiring MCP into local coding
 workflows.
+
+## r/ClaudeAI
+
+> Reminder: do not post until the package is published on PyPI and the release
+> smoke test passes (see top-of-file gate).
+
+Title: Local MCP server that gives Claude precise Python stdlib docs
+
+I built `python-docs-mcp-server`, a small read-only MCP server that drops into
+Claude Desktop or Claude Code and gives Claude exact access to the official
+Python standard library documentation.
+
+It runs on Python 3.12+ and indexes docs for Python 3.10 through 3.14.
+
+Why I built it:
+
+- Claude is strong on Python but answers can drift between stdlib versions
+- generic docs MCP servers pull in noise from broad web sources
+- I wanted Claude to retrieve one official stdlib section, not a whole page
+- the MCP tools are read-only, so the operational story is boring
+
+How I use it: I ask Claude things like "in Python 3.13, what does
+`asyncio.TaskGroup` change vs older asyncio patterns?" and it retrieves the
+exact section from the official 3.13 docs instead of guessing from generic
+web results.
+
+Repo: https://github.com/ayhammouda/python-docs-mcp-server
+
+PyPI publishing is still being finalized. For now, test from source:
+
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
+```
+
+Feedback welcome on Claude Desktop / Claude Code MCP config, retrieval
+quality, and which stdlib lookups feel clunky in real use.

--- a/docs/launch/reddit-posts.md
+++ b/docs/launch/reddit-posts.md
@@ -1,0 +1,67 @@
+# Reddit launch drafts
+
+Do not post these until the package is published on PyPI and the release smoke
+test passes. Until then, use the GitHub `uvx --from git+...` install command.
+
+## r/Python
+
+Title: I built a local MCP server for official Python stdlib docs
+
+I built `mcp-server-python-docs`, a small read-only MCP server that gives AI
+coding agents access to the official Python standard library docs.
+
+Why I wanted it:
+
+- exact stdlib symbol lookup via Python `objects.inv`
+- version-aware answers for Python 3.10 through 3.14
+- section-level retrieval instead of dumping whole pages into context
+- local SQLite/FTS index, no runtime web scraping, no API keys
+- read-only MCP tools, so the operational/security story is boring
+
+Example use case: ask an agent about `asyncio.TaskGroup` in Python 3.13 and it
+can retrieve the exact official docs section instead of guessing from generic web
+results.
+
+Repo: https://github.com/ayhammouda/python-docs-mcp-server
+
+Current note: PyPI publishing is still being finalized. For now, test from
+source:
+
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+```
+
+Feedback welcome, especially on retrieval quality, MCP client setup, and which
+stdlib docs workflows feel clunky in real use.
+
+## r/LocalLLaMA
+
+Title: Local MCP server for official Python docs, built for coding agents
+
+I made a local MCP server for Python standard library documentation. It builds a
+local index from the official docs and exposes small read-only tools for search
+and section retrieval.
+
+The goal is not to be a universal docs search engine. It is the opposite: a
+boring, precise source for Python stdlib questions where version matters and
+tokens are limited.
+
+What it does:
+
+- official Python docs only for stdlib retrieval
+- Python-version-aware results across 3.10-3.14
+- exact symbol lookup from `objects.inv`
+- local SQLite + FTS5 index
+- no API keys or hosted retrieval dependency at query time
+
+Repo: https://github.com/ayhammouda/python-docs-mcp-server
+
+PyPI publishing is not done yet, so don't use the plain `uvx` package command
+until that lands. Source install smoke test:
+
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+```
+
+I'd appreciate practical feedback from people wiring MCP into local coding
+workflows.

--- a/docs/launch/reddit-posts.md
+++ b/docs/launch/reddit-posts.md
@@ -7,8 +7,10 @@ test passes. Until then, use the GitHub `uvx --from git+...` install command.
 
 Title: I built a local MCP server for official Python stdlib docs
 
-I built `mcp-server-python-docs`, a small read-only MCP server that gives AI
+I built `python-docs-mcp-server`, a small read-only MCP server that gives AI
 coding agents access to the official Python standard library docs.
+
+It runs on Python 3.12+ and indexes docs for Python 3.10 through 3.14.
 
 Why I wanted it:
 
@@ -28,7 +30,7 @@ Current note: PyPI publishing is still being finalized. For now, test from
 source:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 
 Feedback welcome, especially on retrieval quality, MCP client setup, and which
@@ -36,11 +38,16 @@ stdlib docs workflows feel clunky in real use.
 
 ## r/LocalLLaMA
 
+> Reminder: do not post until the package is published on PyPI and the release
+> smoke test passes (see top-of-file gate).
+
 Title: Local MCP server for official Python docs, built for coding agents
 
 I made a local MCP server for Python standard library documentation. It builds a
 local index from the official docs and exposes small read-only tools for search
 and section retrieval.
+
+It runs on Python 3.12+ and indexes docs for Python 3.10 through 3.14.
 
 The goal is not to be a universal docs search engine. It is the opposite: a
 boring, precise source for Python stdlib questions where version matters and
@@ -49,7 +56,7 @@ tokens are limited.
 What it does:
 
 - official Python docs only for stdlib retrieval
-- Python-version-aware results across 3.10-3.14
+- Python-version-aware results across 3.10 through 3.14
 - exact symbol lookup from `objects.inv`
 - local SQLite + FTS5 index
 - no API keys or hosted retrieval dependency at query time
@@ -60,7 +67,7 @@ PyPI publishing is not done yet, so don't use the plain `uvx` package command
 until that lands. Source install smoke test:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 
 I'd appreciate practical feedback from people wiring MCP into local coding

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,0 +1,39 @@
+# Show HN launch draft
+
+Do not submit until PyPI publishing is complete and the release smoke test passes.
+
+## Title
+
+Show HN: Local MCP server for official Python standard library docs
+
+## Post
+
+Hi HN — I built `mcp-server-python-docs`, a read-only MCP server that gives AI
+coding agents precise access to the official Python standard library docs.
+
+The motivation: generic docs retrieval is often noisy for stdlib questions.
+Python answers are sensitive to exact symbols and versions, and agents do not
+need a whole docs page when one section answers the question.
+
+What it does:
+
+- builds a local SQLite/FTS index from official Python docs
+- resolves exact symbols from Python `objects.inv`
+- retrieves section-level docs with truncation and pagination
+- supports version-aware lookup across Python 3.10 through 3.14
+- runs locally, read-only, with no API keys
+
+It is intentionally narrow. Use Context7 or generic retrieval for broad
+third-party docs and web research. Use this when you want official stdlib docs
+with less token waste.
+
+Repo: https://github.com/ayhammouda/python-docs-mcp-server
+
+PyPI publishing is still pending. Until that is finished, test from GitHub:
+
+```bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+```
+
+I'd love feedback on the MCP interface, retrieval output, and whether the local
+indexing flow is clear enough.

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -28,6 +28,10 @@ What it does:
 - supports version-aware lookup across Python 3.10 through 3.14
 - runs locally, read-only, with no API keys
 
+Demo query:
+
+- "In Python 3.13, what does `asyncio.TaskGroup` change compared to older asyncio patterns?"
+
 It is intentionally narrow. Use Context7 or generic retrieval for broad
 third-party docs and web research. Use this when you want official stdlib docs
 with less token waste.
@@ -67,6 +71,10 @@ What it does:
 - retrieves section-level docs with truncation and pagination
 - supports version-aware lookup across Python 3.10 through 3.14
 - runs locally, read-only, with no API keys
+
+Demo query:
+
+- "In Python 3.13, what does `asyncio.TaskGroup` change compared to older asyncio patterns?"
 
 Repo: https://github.com/ayhammouda/python-docs-mcp-server
 

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -73,7 +73,7 @@ Repo: https://github.com/ayhammouda/python-docs-mcp-server
 First run after the PyPI release:
 
 ```bash
-uvx python-docs-mcp-server build-index --versions 3.12,3.13
+uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
 
 Then wire `uvx python-docs-mcp-server` into your MCP client and try the README's

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -11,8 +11,10 @@ Feedback: Local MCP server for official Python standard library docs
 
 ### Post
 
-Hi HN -- I built `mcp-server-python-docs`, a read-only MCP server that gives AI
+Hi HN -- I built `python-docs-mcp-server`, a read-only MCP server that gives AI
 coding agents precise access to the official Python standard library docs.
+
+It runs on Python 3.12+ and indexes docs for Python 3.10 through 3.14.
 
 The motivation: generic docs retrieval is often noisy for stdlib questions.
 Python answers are sensitive to exact symbols and versions, and agents do not
@@ -35,7 +37,7 @@ Repo: https://github.com/ayhammouda/python-docs-mcp-server
 PyPI publishing is still pending. Until that is finished, test from GitHub:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 
 I'd love feedback on the MCP interface, retrieval output, and whether the local
@@ -49,8 +51,10 @@ Show HN: Local MCP server for official Python standard library docs
 
 ### Post
 
-Hi HN -- I built `mcp-server-python-docs`, a read-only MCP server that gives AI
+Hi HN -- I built `python-docs-mcp-server`, a read-only MCP server that gives AI
 coding agents precise access to the official Python standard library docs.
+
+It runs on Python 3.12+ and indexes docs for Python 3.10 through 3.14.
 
 The motivation: generic docs retrieval is often noisy for stdlib questions.
 Python answers are sensitive to exact symbols and versions, and agents do not
@@ -66,11 +70,12 @@ What it does:
 
 Repo: https://github.com/ayhammouda/python-docs-mcp-server
 
-Install after the PyPI release:
+First run after the PyPI release:
 
 ```bash
-uvx mcp-server-python-docs --version
+uvx python-docs-mcp-server build-index --versions 3.12,3.13
 ```
 
-I'd love feedback on the MCP interface, retrieval output, and whether the local
-indexing flow is clear enough.
+Then wire `uvx python-docs-mcp-server` into your MCP client and try the README's
+30-second demo. I'd love feedback on the MCP interface, retrieval output, and
+whether the local indexing flow is clear enough.

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,14 +1,17 @@
 # Show HN launch draft
 
-Do not submit until PyPI publishing is complete and the release smoke test passes.
+Use the pre-PyPI draft for private feedback only. Submit the post-PyPI draft to
+HN only after PyPI publishing is complete and the release smoke test passes.
 
-## Title
+## Pre-PyPI feedback draft
 
-Show HN: Local MCP server for official Python standard library docs
+### Title
 
-## Post
+Feedback: Local MCP server for official Python standard library docs
 
-Hi HN — I built `mcp-server-python-docs`, a read-only MCP server that gives AI
+### Post
+
+Hi HN -- I built `mcp-server-python-docs`, a read-only MCP server that gives AI
 coding agents precise access to the official Python standard library docs.
 
 The motivation: generic docs retrieval is often noisy for stdlib questions.
@@ -33,6 +36,40 @@ PyPI publishing is still pending. Until that is finished, test from GitHub:
 
 ```bash
 uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git mcp-server-python-docs --version
+```
+
+I'd love feedback on the MCP interface, retrieval output, and whether the local
+indexing flow is clear enough.
+
+## Post-PyPI Show HN draft
+
+### Title
+
+Show HN: Local MCP server for official Python standard library docs
+
+### Post
+
+Hi HN -- I built `mcp-server-python-docs`, a read-only MCP server that gives AI
+coding agents precise access to the official Python standard library docs.
+
+The motivation: generic docs retrieval is often noisy for stdlib questions.
+Python answers are sensitive to exact symbols and versions, and agents do not
+need a whole docs page when one section answers the question.
+
+What it does:
+
+- builds a local SQLite/FTS index from official Python docs
+- resolves exact symbols from Python `objects.inv`
+- retrieves section-level docs with truncation and pagination
+- supports version-aware lookup across Python 3.10 through 3.14
+- runs locally, read-only, with no API keys
+
+Repo: https://github.com/ayhammouda/python-docs-mcp-server
+
+Install after the PyPI release:
+
+```bash
+uvx mcp-server-python-docs --version
 ```
 
 I'd love feedback on the MCP interface, retrieval output, and whether the local

--- a/docs/superpowers/plans/2026-05-11-pr22-coherence-fixes.md
+++ b/docs/superpowers/plans/2026-05-11-pr22-coherence-fixes.md
@@ -1,0 +1,864 @@
+# PR #22 Coherence Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the seven coherence / consistency gaps flagged in the deep code review of PR #22 (`fix/autonomous-launch-pack`) before launch, so the post-PyPI cleanup pass and back-compat experience are mechanically safe.
+
+**Architecture:** Most fixes are isolated edits to a single file each (README, pyproject, two test files, one launch draft). The one cross-cutting fix is the PRE-PYPI marker scope in README, which is restructured so a single `<!-- PRE-PYPI -->`…`<!-- /PRE-PYPI -->` block encloses every transient section (heading + lead-in sentence + code), making the committed cleanup regex a complete safety net.
+
+**Tech Stack:** Python 3.12+, pytest, ruff, `uv build`, click, FastMCP. No new dependencies.
+
+---
+
+## Scope check
+
+Seven fixes from the review map to the following files:
+
+| Fix | File(s) |
+|-----|---------|
+| **C1** + **I1** | `README.md` (marker scope) + `.github/RELEASE.md` (anchor expected regex output to the new structure) |
+| **I4** | `pyproject.toml` (add 3.14 classifier) |
+| **I5** | `docs/launch/show-hn.md` (reconcile build-index versions) |
+| **I6** | `README.md` (Troubleshooting subsection for legacy CLI users) |
+| **I3** | `tests/test_packaging.py` (harden source-tree fallback test) |
+| **M1** | `tests/test_services.py` (assert FastMCP server name) |
+| **M2** | `tests/test_packaging.py` (structurally parse entry_points.txt) |
+
+I3 and M2 both touch `tests/test_packaging.py` and are merged into a single task to keep one atomic commit per file-touch. C1 and I1 are merged because they share a single structural change to the README markers. Total: 7 tasks across 5 files. Each task produces a green test suite and a commit.
+
+---
+
+## File structure
+
+**Files to be modified (no new files):**
+
+- `README.md` — restructure `<!-- PRE-PYPI -->` markers to enclose full transient sections; add Troubleshooting subsection on legacy CLI back-compat
+- `.github/RELEASE.md` — anchor the post-PyPI cleanup checklist to the new marker structure (the regex itself can stay as-is once C1+I1 are fixed because the surrounding prose now lives inside marker blocks)
+- `pyproject.toml` — add `Programming Language :: Python :: 3.14` classifier
+- `docs/launch/show-hn.md` — change post-PyPI `build-index --versions` to the full 5-version list to match README
+- `tests/test_packaging.py` — (I3) force the fallback path via monkey-patched `importlib.metadata.version` in the source-tree test; (M2) replace substring assertions on `entry_points.txt` with `configparser` parsing
+- `tests/test_services.py` — (M1) add a one-liner asserting `create_server()` reports identity `python-docs-mcp-server`
+
+**No file is created.** No package layout change. No dependency change.
+
+---
+
+## Task 1: Restructure PRE-PYPI markers to enclose full transient sections (C1 + I1)
+
+**Files:**
+- Modify: `README.md` — five disjoint regions:
+  - Block A (30-second demo): lines 74-80
+  - Block B (Install section): lines 84-100
+  - Block C (First run): lines 115-123
+  - Block D (Claude Desktop / Cursor / Codex configs): lines 147-164, 184-201, 218-226
+  - Block E (Diagnostics): lines 314-324, 332-343
+- Modify: `.github/RELEASE.md` (cleanup checklist around line 165; the verification regex around line 170 stays as-is once markers are widened)
+- Test: ad-hoc shell command — `rg` execution against the marker-stripped README
+
+**Why this matters:** The current `<!-- PRE-PYPI -->` markers only wrap code fences, leaving surrounding lead-in sentences ("Local source smoke test until the PyPI package is published:") and `### Before/After PyPI publishing` headings *outside* any marker. The committed cleanup regex at `.github/RELEASE.md:170` is also case-sensitive and misses line 74's lowercase phrasing. Combined, this means a maintainer who runs the regex post-launch will see zero hits and ship while transient prose remains on the published README.
+
+Fix: widen each `<!-- PRE-PYPI -->` block to enclose the heading + lead-in sentence + the GitHub-source code fence. Then on cleanup day, a maintainer can sed/perl-delete every `<!-- PRE-PYPI -->`…`<!-- /PRE-PYPI -->` block and the README will end up clean in one pass.
+
+- [ ] **Step 1: Write the failing verification command**
+
+Create a file `scripts/verify_pre_pypi_cleanup.sh` (or just record the command in your terminal scratch — no need to commit the script). Run it against current README:
+
+```bash
+# 1) Strip everything between PRE-PYPI markers
+perl -0777 -pe 's/<!-- PRE-PYPI:.*?<!-- \/PRE-PYPI -->//gs' README.md > /tmp/README.stripped.md
+
+# 2) Confirm no transient prose survives outside markers
+rg -in 'PRE[-]PYPI|Before PyPI publishing|Until.+PyPI|After PyPI publishing|git\+https://github.com/.*python-docs-mcp-server' /tmp/README.stripped.md
+```
+
+Expected: at least lines for `Before PyPI publishing`, `Until the first PyPI release is published`, `Local source smoke test until the PyPI package is published`, `After PyPI publishing, use:` show up — proving the current markers are too narrow.
+
+- [ ] **Step 2: Widen marker scopes in README.md**
+
+Apply the following edits (preserve exact existing text; only the marker placement changes).
+
+**Note on fence rendering in this plan:** the snippets below contain code fences inside Markdown code fences. To avoid breaking this plan's own outer fences, every inner triple-backtick is rendered as space-padded ` ` ` (` ` `bash, ` ` `json, ` ` `toml, etc.). **When writing to README.md, translate each space-padded ` ` ` back to a real triple-backtick (\`\`\`).** Verify fence parity per Step 6 / Task 7.
+
+**Block A — 30-second demo (lines 74-80):**
+
+Current:
+```markdown
+Local source smoke test until the PyPI package is published:
+
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+` ` ` bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
+` ` `
+<!-- /PRE-PYPI -->
+```
+
+Replace with:
+```markdown
+<!-- PRE-PYPI: replace this temporary GitHub-source smoke test after the first PyPI publish -->
+Local source smoke test until the PyPI package is published:
+
+` ` ` bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
+` ` `
+<!-- /PRE-PYPI -->
+```
+
+**Block B — Install section (lines 84-100):**
+
+Current structure:
+```markdown
+### Before PyPI publishing (install from GitHub source)
+
+Until the first PyPI release is published, run from GitHub:
+
+<!-- PRE-PYPI: ... -->
+` ` ` bash
+uvx --from git+...
+` ` `
+<!-- /PRE-PYPI -->
+
+### After PyPI publishing
+
+Run directly with `uvx`:
+` ` ` bash
+uvx python-docs-mcp-server --version
+` ` `
+```
+
+Replace with:
+```markdown
+<!-- PRE-PYPI: remove this entire "Before PyPI publishing" block (heading + prose + code) after the first PyPI publish -->
+### Before PyPI publishing (install from GitHub source)
+
+Until the first PyPI release is published, run from GitHub:
+
+` ` ` bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
+` ` `
+<!-- /PRE-PYPI -->
+
+<!-- PRE-PYPI: after the first PyPI publish, drop this "After PyPI publishing" heading so the section reads simply as "## Install" -->
+### After PyPI publishing
+<!-- /PRE-PYPI -->
+
+Run directly with `uvx`:
+` ` ` bash
+uvx python-docs-mcp-server --version
+` ` `
+```
+
+**Block C — First run (lines 115-123):**
+
+Current:
+```markdown
+Build the local documentation index:
+
+<!-- PRE-PYPI: replace this temporary GitHub source command after the first PyPI publish -->
+` ` ` bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+` ` `
+<!-- /PRE-PYPI -->
+
+After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
+
+If you installed the package persistently, you can drop the `uvx` prefix:
+```
+
+Replace with:
+```markdown
+Build the local documentation index:
+
+<!-- PRE-PYPI: remove the GitHub-source build-index command and the "After PyPI publishing" lead-in after the first PyPI publish; the post-PyPI code fence below survives -->
+` ` ` bash
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+` ` `
+
+After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
+<!-- /PRE-PYPI -->
+
+` ` ` bash
+uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+` ` `
+
+If you installed the package persistently, you can drop the `uvx` prefix:
+```
+
+Rationale: post-cleanup, the section becomes "Build the local documentation index: → `uvx python-docs-mcp-server build-index ...` (full 5 versions) → If you installed persistently, drop uvx prefix". The canonical post-PyPI uvx command is preserved as the visible example. The transient GitHub-source command and its "After PyPI publishing" qualifier disappear together.
+
+**Block D — Claude Desktop, Cursor, Codex configs (lines 147-201, 215-226):** wrap each `<!-- PRE-PYPI -->` block + the trailing `After PyPI publishing, use:` lead-in inside one marker pair, so cleanup removes the GitHub-source config block AND the "After PyPI publishing, use:" lead-in, leaving only the post-PyPI config code fence.
+
+This applies uniformly to:
+- Claude Desktop JSON config (lines 147-164)
+- Cursor JSON config (lines 184-201)
+- Codex **TOML** config (lines 218-226) — same wrap pattern even though the fence is ` ```toml ` not ` ```json `
+
+Concrete pattern for each (Claude Desktop shown; Cursor and Codex are identical in structure):
+
+Current:
+```markdown
+<!-- PRE-PYPI: ... -->
+` ` ` json
+[github-source config block]
+` ` `
+<!-- /PRE-PYPI -->
+
+After PyPI publishing, use:
+
+` ` ` json
+[post-PyPI config block]
+` ` `
+```
+
+Replace with:
+```markdown
+<!-- PRE-PYPI: remove the GitHub-source config and the "After PyPI publishing, use:" lead-in after the first PyPI publish; the post-PyPI config fence below survives -->
+` ` ` json
+[github-source config block]
+` ` `
+
+After PyPI publishing, use:
+<!-- /PRE-PYPI -->
+
+` ` ` json
+[post-PyPI config block]
+` ` `
+```
+
+After cleanup, the section reads "Add this to your Claude Desktop configuration file: [paths] → [post-PyPI JSON code fence]" with no transient verbiage. The Codex TOML variant follows the same pattern verbatim with TOML fences.
+
+**Block E — Diagnostics (lines 314-324, 332-343):** wrap each "Before PyPI publishing, run `doctor` from the GitHub source package:" lead-in + its pre-PyPI command + the `After PyPI publishing:` lead-in inside one marker pair. The post-PyPI command (e.g., `uvx python-docs-mcp-server doctor`) stays outside the marker.
+
+- [ ] **Step 3: Re-run the verification command**
+
+```bash
+perl -0777 -pe 's/<!-- PRE-PYPI:.*?<!-- \/PRE-PYPI -->//gs' README.md > /tmp/README.stripped.md
+rg -in 'PRE[-]PYPI|Before PyPI publishing|Until.+PyPI|After PyPI publishing|git\+https://github.com/.*python-docs-mcp-server' /tmp/README.stripped.md
+```
+
+Expected: **zero output**. If anything matches, narrow the surviving fragment by widening the corresponding marker.
+
+- [ ] **Step 4: Confirm no badge / verification comment was caught**
+
+The MCP Registry verification comment at `README.md:3` (`<!-- mcp-name: io.github.ayhammouda/python-docs-mcp-server -->`) and the CI/license/PyPI badge lines must survive cleanup. Verify:
+
+```bash
+rg -n 'mcp-name|badge.svg|License: MIT|github.com/ayhammouda/python-docs-mcp-server/actions' /tmp/README.stripped.md
+```
+
+Expected: all four lines present, unaltered.
+
+- [ ] **Step 5: Update RELEASE.md cleanup checklist to reflect the new marker shape**
+
+In `.github/RELEASE.md` around line 165, update the cleanup instruction text. Change:
+
+```markdown
+- [ ] Remove every temporary PyPI pre-release block from `README.md`:
+  - Delete each `<!-- PRE-PYPI: ... -->` through `<!-- /PRE-PYPI -->` region,
+    including the marker comments and GitHub-source replacement commands
+  - Remove or rewrite stale "Before PyPI publishing" headings, "Until the first
+    PyPI release is published" text, and "After PyPI publishing" qualifiers
+```
+
+To:
+
+```markdown
+- [ ] Remove every temporary PyPI pre-release block from `README.md`:
+  - Mechanical pass: delete every region from `<!-- PRE-PYPI:` to `<!-- /PRE-PYPI -->` (inclusive). Each block now encloses its surrounding heading + lead-in sentence + code, so a single pass produces a clean README.
+  - Reference command:
+    `perl -0777 -i -pe 's/<!-- PRE-PYPI:.*?<!-- \/PRE-PYPI -->\n*//gs' README.md`
+```
+
+Then leave the existing `rg` verification command as the safety net.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add README.md .github/RELEASE.md
+git commit -m "$(cat <<'EOF'
+docs(readme): widen PRE-PYPI markers to enclose full transient sections
+
+Fixes C1+I1 from the PR #22 coherence review: previously the
+<!-- PRE-PYPI --> markers wrapped only code fences, leaving
+surrounding "Before/After PyPI publishing" headings and lead-in
+sentences (including line 74's lowercase "until the PyPI package
+is published") outside any marker. The committed cleanup regex
+missed line 74, so post-launch a mechanical block-delete would
+have left transient prose on the published README.
+
+Each PRE-PYPI block now encloses its full transient region. The
+RELEASE.md cleanup checklist references a perl one-liner for a
+single-pass mechanical cleanup.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add Python 3.14 to pyproject.toml classifiers (I4)
+
+**Files:**
+- Modify: `pyproject.toml:16-23`
+- Test: `tests/test_packaging.py` (new test asserting classifier presence)
+
+**Why this matters:** Every doc + the Slow E2E workflow advertises support for indexed Python documentation versions 3.10-3.14. The runtime is 3.12+. The classifier list currently stops at 3.13, so PyPI's "Programming Language" filter won't surface this project for 3.14 users. The asymmetry is cosmetic but visible.
+
+(Note: we do NOT add 3.10 / 3.11 classifiers because `requires-python = ">=3.12"` — those runtimes can't run the server. The 3.10-3.14 range is for *indexed documentation versions*, not runtime support.)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_packaging.py` inside the `TestPyprojectDeps` class:
+
+```python
+    def test_classifiers_advertise_supported_python_versions(self):
+        """Classifiers must list every Python runtime the project supports."""
+        pyproject = (PROJECT_ROOT / "pyproject.toml").read_text()
+        for minor in (12, 13, 14):
+            classifier = f"Programming Language :: Python :: 3.{minor}"
+            assert classifier in pyproject, f"Missing classifier: {classifier}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+uv run pytest tests/test_packaging.py::TestPyprojectDeps::test_classifiers_advertise_supported_python_versions -v
+```
+
+Expected: FAIL — `Missing classifier: Programming Language :: Python :: 3.14`.
+
+- [ ] **Step 3: Add the classifier to `pyproject.toml`**
+
+Insert at line 21 (after the `3.13` classifier and before `Topic :: Documentation`):
+
+```toml
+    "Programming Language :: Python :: 3.14",
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+uv run pytest tests/test_packaging.py::TestPyprojectDeps::test_classifiers_advertise_supported_python_versions -v
+```
+
+Expected: PASS. Then run the full suite to confirm no regression:
+
+```bash
+uv run pytest -q
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml tests/test_packaging.py
+git commit -m "$(cat <<'EOF'
+build: advertise Python 3.14 runtime in PyPI classifiers
+
+Fixes I4 from the PR #22 coherence review. Slow E2E runs on
+Python 3.13 and 3.14, and all docs say the project runs on
+Python 3.12+. The classifier list previously stopped at 3.13,
+which hid the project from PyPI users filtering by 3.14.
+
+Adds a classifier test to prevent future drift.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Reconcile Show HN `build-index` versions (I5)
+
+**Files:**
+- Modify: `docs/launch/show-hn.md:76`
+
+**Why this matters:** The post-PyPI Show HN draft tells readers to run `uvx python-docs-mcp-server build-index --versions 3.12,3.13` while every other doc (README, AGENTS, CONTRIBUTING, INTEGRATION-TEST, RELEASE, reddit-posts) instructs the full `3.10,3.11,3.12,3.13,3.14` list. A reader who follows the HN post then visits the README will find the index incomplete and have to rebuild. Pick one. The right one is the full list to match the rest of the launch pack.
+
+(Trade-off: the full build takes longer. We could keep `3.12,3.13` and annotate it as a quick-demo build, but consistency wins for a launch post.)
+
+- [ ] **Step 1: Edit `docs/launch/show-hn.md` line 76**
+
+Change:
+```bash
+uvx python-docs-mcp-server build-index --versions 3.12,3.13
+```
+
+To:
+```bash
+uvx python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+```
+
+- [ ] **Step 2: Verify launch-pack and user-facing docs match**
+
+```bash
+rg -n 'build-index --versions' docs/launch/ README.md CONTRIBUTING.md .github/
+```
+
+Expected: every result lists `3.10,3.11,3.12,3.13,3.14`. No outliers.
+
+Note: `AGENTS.md:42` deliberately uses `--versions 3.12,3.13` as a contributor quick-build for fast inner-loop iteration (it sits under the "Build and inspect a local docs index" instructions, not in the launch pack). It is **excluded** from this verification on purpose. If you need to confirm: open `AGENTS.md` around line 38-44 — the surrounding text is a contributor workflow, not a user-facing launch instruction.
+
+Out-of-scope reconciliation: if Task 3 grows to also normalize `AGENTS.md`, that would conflict with its role as a fast contributor doc. Keep this task narrowly scoped to user-facing launch/install docs.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/launch/show-hn.md
+git commit -m "$(cat <<'EOF'
+docs(launch): reconcile Show HN build-index versions with README
+
+Fixes I5 from the PR #22 coherence review. The Show HN draft
+previously instructed building only 3.12,3.13 while every other
+doc instructed the full 3.10,3.11,3.12,3.13,3.14 list. A reader
+who followed the HN post and then the README would find the
+index incomplete.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add Troubleshooting subsection for legacy CLI users (I6)
+
+**Files:**
+- Modify: `README.md` — add a subsection under `## Troubleshooting`
+
+**Why this matters:** Once the new PyPI project goes live, a user whose MCP config still says `uvx mcp-server-python-docs` will hit a PyPI lookup error because the new project name is `python-docs-mcp-server`. The legacy CLI alias works only *after* the new package is installed by its real name; it does NOT survive `uvx`-style "install-and-run by project name" lookups. This needs an explicit note.
+
+- [ ] **Step 1: Read current Troubleshooting structure**
+
+```bash
+sed -n '350,410p' README.md
+```
+
+Note where the `### uvx cache stale` subsection starts (~ line 384). Insert the new subsection immediately before it.
+
+- [ ] **Step 2: Add the subsection**
+
+Insert (immediately before `### uvx cache stale`):
+
+```markdown
+### Migrating from the pre-rename CLI
+
+Earlier development snapshots of this project used the PyPI name
+`mcp-server-python-docs`. The published PyPI project is
+`python-docs-mcp-server`. If your MCP client config still references
+the old name via `uvx`, you will see a `Package not found` error,
+because `uvx` resolves projects by PyPI name.
+
+Update your config's `args` from:
+
+` ` ` json
+"args": ["mcp-server-python-docs"]
+` ` `
+
+to:
+
+` ` ` json
+"args": ["python-docs-mcp-server"]
+` ` `
+
+The wheel still installs a legacy `mcp-server-python-docs` console
+script for users who already have the package installed and invoke
+the binary by name on `$PATH`. That script is an alias and will be
+removed in a future release.
+```
+
+(Use real triple-backticks in the file; the spacing here is just to avoid breaking this plan's own fences.)
+
+- [ ] **Step 3: Verify no Markdown breakage**
+
+```bash
+uv run python -c "import pathlib; print(pathlib.Path('README.md').read_text().count('\`\`\`'))"
+```
+
+Expected: even number (each code fence opens and closes).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+docs(readme): document migration from pre-rename CLI
+
+Fixes I6 from the PR #22 coherence review. After the new PyPI
+project goes live, users whose MCP client config still references
+`uvx mcp-server-python-docs` will get a PyPI lookup error. The
+legacy console-script alias only helps users who already have the
+package installed and invoke the binary by name on $PATH.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Harden `tests/test_packaging.py` — force source-tree fallback + structurally parse entry_points.txt (I3 + M2)
+
+**Files:**
+- Modify: `tests/test_packaging.py` (two unrelated tests touched together to keep one commit per file)
+
+**Why this matters:**
+
+- **I3:** The current `test_source_tree_import_without_installed_metadata` uses `python -S` to disable `site.py`. The reviewer empirically confirmed that `-S` does NOT clear an editable install's `.dist-info` from `sys.path` discovery — the test currently passes because the metadata version coincidentally equals the pyproject version. If a developer bumps the pyproject version without reinstalling the editable distribution, the test will silently pass while exercising the *installed-metadata* path, not the fallback. We need to force the fallback.
+- **M2:** `test_wheel_has_entry_point` uses `assert DIST_NAME in content` against the raw `entry_points.txt` text. Three substrings can all appear without being bound to the right callable in the right section. Parse the file structurally via `configparser`.
+
+- [ ] **Step 1: Write the hardened fallback test**
+
+Replace the body of `test_source_tree_import_without_installed_metadata` (currently `tests/test_packaging.py:122-144`) with:
+
+```python
+    def test_source_tree_import_without_installed_metadata(self, tmp_path: Path):
+        """Source-tree import falls back to pyproject.toml when metadata is absent.
+
+        Forces the fallback path by monkey-patching importlib.metadata.version
+        to raise PackageNotFoundError, since `-S` alone does not reliably
+        suppress editable-install dist-info discovery.
+        """
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+        prelude = (
+            "import importlib.metadata as m\n"
+            "def _raise(_):\n"
+            "    raise m.PackageNotFoundError\n"
+            "m.version = _raise\n"
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-S",
+                "-c",
+                prelude + "import mcp_server_python_docs; print(mcp_server_python_docs.__version__)",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+            cwd=str(tmp_path),
+        )
+        assert result.returncode == 0, (
+            f"Source-tree import failed.\n"
+            f"stdout: {result.stdout!r}\n"
+            f"stderr: {result.stderr!r}"
+        )
+        # The fallback reads pyproject.toml directly; assert it equals
+        # whatever pyproject currently declares (decoupled from installed metadata).
+        import tomllib
+        pyproject_version = tomllib.loads(
+            (PROJECT_ROOT / "pyproject.toml").read_text()
+        )["project"]["version"]
+        assert result.stdout.strip() == pyproject_version
+```
+
+- [ ] **Step 2: Write the hardened entry-point test**
+
+Replace the body of `test_wheel_has_entry_point` (currently `tests/test_packaging.py:79-90`) with:
+
+```python
+    def test_wheel_has_entry_point(self, built_wheel):
+        """PKG-01: Wheel metadata declares both console scripts, structurally."""
+        import configparser
+        import io
+
+        with zipfile.ZipFile(built_wheel) as zf:
+            entry_point_files = [
+                n for n in zf.namelist() if n.endswith("entry_points.txt")
+            ]
+            assert len(entry_point_files) == 1
+            content = zf.read(entry_point_files[0]).decode()
+
+        parser = configparser.ConfigParser()
+        parser.read_file(io.StringIO(content))
+        assert parser.has_section("console_scripts"), (
+            f"entry_points.txt missing [console_scripts]:\n{content}"
+        )
+        scripts = dict(parser.items("console_scripts"))
+        target = "mcp_server_python_docs.__main__:main"
+        assert scripts.get(DIST_NAME) == target, (
+            f"Expected {DIST_NAME} -> {target}, got {scripts!r}"
+        )
+        assert scripts.get(LEGACY_CLI_NAME) == target, (
+            f"Expected {LEGACY_CLI_NAME} -> {target}, got {scripts!r}"
+        )
+```
+
+- [ ] **Step 3: Run both updated tests, expect green**
+
+```bash
+uv run pytest tests/test_packaging.py::TestVersionFlag::test_source_tree_import_without_installed_metadata tests/test_packaging.py::TestWheelContent::test_wheel_has_entry_point -v
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 4: Verify the hardened fallback test actually fails when the fallback is broken**
+
+This step has three sub-steps that MUST be completed in order. The temporary edit MUST be reverted before continuing.
+
+**Step 4a — break:** In `src/mcp_server_python_docs/__init__.py`, replace the line:
+```python
+            return tomllib.load(fh)["project"]["version"]
+```
+with:
+```python
+            return "BOGUS"  # TEMPORARY — revert before commit
+```
+
+**Step 4b — assert failure:**
+```bash
+uv run pytest tests/test_packaging.py::TestVersionFlag::test_source_tree_import_without_installed_metadata -v
+```
+Expected: FAIL — assertion mismatch `'BOGUS' != '0.1.1'`. If the test PASSES, the fallback is not being exercised and you must re-examine the monkey-patch from Step 1 before proceeding.
+
+**Step 4c — revert and verify clean tree:** Restore `__init__.py` exactly:
+```python
+            return tomllib.load(fh)["project"]["version"]
+```
+
+Then confirm the revert was complete:
+```bash
+git diff src/mcp_server_python_docs/__init__.py
+```
+Expected: **empty output**. If the diff shows anything, fix it before continuing — the test commit MUST NOT include any change to `src/`.
+
+Re-run the test to confirm green:
+```bash
+uv run pytest tests/test_packaging.py::TestVersionFlag::test_source_tree_import_without_installed_metadata -v
+```
+Expected: PASS.
+
+- [ ] **Step 5: Run full suite**
+
+```bash
+uv run pytest -q
+```
+
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_packaging.py
+git commit -m "$(cat <<'EOF'
+test(packaging): harden source-tree fallback + entry-point assertions
+
+Fixes I3 + M2 from the PR #22 coherence review.
+
+I3: -S does not reliably suppress editable-install dist-info
+discovery, so the source-tree fallback test was previously passing
+because installed metadata happened to match pyproject. Force the
+fallback by monkey-patching importlib.metadata.version to raise
+PackageNotFoundError.
+
+M2: Replace substring assertions on entry_points.txt with
+configparser parsing that verifies each console script is bound
+to mcp_server_python_docs.__main__:main, not merely substring-
+present.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Assert FastMCP server identity (M1)
+
+**Files:**
+- Modify: `tests/test_services.py` (add one test method to an existing class)
+
+**Why this matters:** `src/mcp_server_python_docs/server.py:222` constructs `FastMCP("python-docs-mcp-server", ...)`. No test currently asserts that identity. If a future rename touches the FastMCP constructor without updating docs (or vice versa), nothing breaks loudly. One-line lock.
+
+- [ ] **Step 1: Empirically confirm the FastMCP identity attribute**
+
+Before writing the test, verify that `server.name` is the correct attribute (it is, for `mcp>=1.27.0`, the version pinned in `pyproject.toml`):
+
+```bash
+uv run python -c "from mcp_server_python_docs.server import create_server; s=create_server(); print([a for a in dir(s) if 'name' in a.lower()])"
+```
+
+Expected output: `['name']` (a single attribute). If you see additional candidates (e.g., `_server_name`, `server_info`), test each with `print(getattr(s, attr))` and pick the one that returns `"python-docs-mcp-server"`. Note the chosen attribute for use in Step 2.
+
+- [ ] **Step 2: Write the test**
+
+In `tests/test_services.py`, locate `def test_create_server_has_three_tools(self):` around line 411. Add a sibling method (assuming `server.name` from Step 1; substitute the verified attribute if different):
+
+```python
+    def test_create_server_identifies_as_dist_name(self):
+        """FastMCP server name must match the public distribution name."""
+        from mcp_server_python_docs.server import create_server
+
+        server = create_server()
+        # FastMCP exposes the constructor name via .name (mcp >= 1.27)
+        assert server.name == "python-docs-mcp-server", (
+            f"Expected FastMCP name 'python-docs-mcp-server', got {server.name!r}"
+        )
+```
+
+- [ ] **Step 2b: Run test to verify it passes**
+
+```bash
+uv run pytest tests/test_services.py -k test_create_server_identifies_as_dist_name -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Mutation-test the assertion**
+
+Three sub-steps; the temporary edit MUST be reverted before continuing.
+
+**Step 3a — break:** In `src/mcp_server_python_docs/server.py:222`, change:
+```python
+    mcp = FastMCP(
+        "python-docs-mcp-server",
+        lifespan=app_lifespan,
+    )
+```
+to:
+```python
+    mcp = FastMCP(
+        "nope",  # TEMPORARY — revert before commit
+        lifespan=app_lifespan,
+    )
+```
+
+**Step 3b — assert failure:**
+```bash
+uv run pytest tests/test_services.py -k test_create_server_identifies_as_dist_name -v
+```
+Expected: FAIL with the assertion message `Expected FastMCP name 'python-docs-mcp-server', got 'nope'`. If it PASSES, the assertion is not exercising the constructor — re-examine Step 2 before proceeding.
+
+**Step 3c — revert and verify clean tree:** Restore `server.py:222` exactly:
+```python
+    mcp = FastMCP(
+        "python-docs-mcp-server",
+        lifespan=app_lifespan,
+    )
+```
+
+Confirm the revert was complete:
+```bash
+git diff src/mcp_server_python_docs/server.py
+```
+Expected: **empty output**. The test commit MUST NOT include any change to `src/`.
+
+Re-run to confirm green:
+```bash
+uv run pytest tests/test_services.py -k test_create_server_identifies_as_dist_name -v
+```
+Expected: PASS.
+
+- [ ] **Step 4: Run full suite**
+
+```bash
+uv run pytest -q
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_services.py
+git commit -m "$(cat <<'EOF'
+test(services): lock FastMCP server identity to dist name
+
+Fixes M1 from the PR #22 coherence review. server.py:222
+constructs FastMCP("python-docs-mcp-server", ...), but no test
+asserts that identity. A future rename that touches the
+constructor without updating docs (or vice versa) would have
+been a silent drift. One assertion locks it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Final cross-check + PR update
+
+**Files:**
+- None modified — verification + PR description / commit log
+
+**Why this matters:** A coherence fix-up batch should end with the same kind of cross-cutting verification it was kicked off to enforce.
+
+- [ ] **Step 1: Full local test sweep**
+
+```bash
+uv run ruff check src/ tests/
+uv run pyright src/
+uv run pytest -q
+uv build
+```
+
+Expected: ruff clean, pyright clean, all tests pass, `uv build` produces both wheel and sdist in `dist/` named `python_docs_mcp_server-0.1.1*`.
+
+- [ ] **Step 2: Re-run the cleanup verification on README**
+
+```bash
+perl -0777 -pe 's/<!-- PRE-PYPI:.*?<!-- \/PRE-PYPI -->//gs' README.md > /tmp/README.stripped.md
+rg -in 'PRE[-]PYPI|Before PyPI publishing|Until.+PyPI|After PyPI publishing|git\+https://github.com/.*python-docs-mcp-server' /tmp/README.stripped.md
+```
+
+Expected: zero output.
+
+- [ ] **Step 3: Re-run the dist-name leak scan**
+
+```bash
+rg -n 'mcp-server-python-docs' --type-add 'web:*.{md,toml,json,yml,yaml,sql,py}' -t web \
+  | grep -v '^\.planning/' \
+  | grep -v '^docs/superpowers/' \
+  | grep -v '^uv.lock' \
+  | grep -v '^CODE-REVIEW-PR' \
+  | grep -v '^\.claude/'
+```
+
+Expected output (exact, one line per occurrence — counts may differ slightly by README Troubleshooting line numbers):
+
+- 1 line: `pyproject.toml:48:mcp-server-python-docs = "mcp_server_python_docs.__main__:main"` (legacy `[project.scripts]` alias)
+- 1 line: `tests/test_packaging.py:20:LEGACY_CLI_NAME = "mcp-server-python-docs"` — this is the **only** line in `tests/test_packaging.py` where the string literal appears. The entry-point structural test rewritten in Task 5 references `LEGACY_CLI_NAME` by variable name, so it does **not** show up in this scan.
+- 2-4 lines: `README.md` Troubleshooting subsection added in Task 4 (the heading mentions the old name, plus 1-3 lines of body text with `"mcp-server-python-docs"` literal)
+
+If you see any other hit, treat it as a leak and fix it before pushing. Compare against this expected list explicitly — do not just count.
+
+- [ ] **Step 4: Push and update PR description**
+
+```bash
+git push
+```
+
+In the PR description, add a section noting the coherence fix-pack:
+
+> **Coherence fix-pack (post-review):**
+>
+> - C1+I1: widened `<!-- PRE-PYPI -->` markers in README to enclose full transient sections; updated RELEASE.md cleanup checklist with a perl one-liner for a mechanical single-pass cleanup
+> - I3: hardened source-tree fallback test by monkey-patching `importlib.metadata.version`
+> - I4: added `Programming Language :: Python :: 3.14` classifier + classifier-presence test
+> - I5: reconciled Show HN `build-index` to the full 5-version list
+> - I6: added Troubleshooting subsection for legacy CLI users
+> - M1: added FastMCP server identity assertion
+> - M2: replaced substring assertions on `entry_points.txt` with `configparser` parsing
+
+- [ ] **Step 5: Request a second-pass code review**
+
+Use the `superpowers:requesting-code-review` skill with `BASE_SHA=<head of original PR>` and `HEAD_SHA=<HEAD>` to verify the fix-pack cleanly addresses the review findings.
+
+---
+
+## Notes for the executor
+
+- Steps in Task 1 modify a single file (README.md) in multiple disjoint hunks. Apply them one block at a time with `Edit` so the file is never in an intermediate state where markers are unbalanced.
+- For Task 5 Step 4 and Task 6 Step 3 (mutation-test the assertion), it is essential to revert the deliberate breakage before re-running the suite. If you forget, the next commit will include the breakage. The plan flags these explicitly because they are easy to skip.
+- Each task ends with one commit. Seven tasks = seven commits. Keep them atomic.
+- Do not touch `uv.lock` manually. If `uv build` re-locks for some reason, include the lock change in the relevant task's commit and note it in the message.
+- Do not modify any file under `src/mcp_server_python_docs/` except as explicitly part of a mutation-test step that is immediately reverted. The fix-pack should be doc + test + pyproject only.
+
+## Out of scope
+
+The reviewer's M3 (banner UX inconsistency where `mcp-server-python-docs --version` prints `python-docs-mcp-server`) is intentional per the PR design and was already documented in the first-pass review. Not touched here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mcp-server-python-docs"
+name = "python-docs-mcp-server"
 version = "0.1.1"
 description = "A read-only, version-aware MCP retrieval server over Python standard library documentation"
 readme = "README.md"
@@ -44,6 +44,7 @@ dev = [
 ]
 
 [project.scripts]
+python-docs-mcp-server = "mcp_server_python_docs.__main__:main"
 mcp-server-python-docs = "mcp_server_python_docs.__main__:main"
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Documentation",
     "Topic :: Software Development :: Libraries",
 ]

--- a/server.json
+++ b/server.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.ayhammouda/python-docs-mcp-server",
+  "description": "Local, read-only MCP retrieval over official Python standard library docs.",
+  "title": "Python Docs MCP Server",
+  "websiteUrl": "https://github.com/ayhammouda/python-docs-mcp-server",
+  "repository": {
+    "url": "https://github.com/ayhammouda/python-docs-mcp-server",
+    "source": "github"
+  },
+  "version": "0.1.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "mcp-server-python-docs",
+      "version": "0.1.1",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "status": "ready-for-validation-after-pypi-publish",
+      "notes": "PyPI package metadata is included for the official MCP Registry, but package publication is tracked separately."
+    }
+  }
+}

--- a/server.json
+++ b/server.json
@@ -13,18 +13,12 @@
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
-      "identifier": "mcp-server-python-docs",
+      "identifier": "python-docs-mcp-server",
       "version": "0.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"
       }
     }
-  ],
-  "_meta": {
-    "io.modelcontextprotocol.registry/publisher-provided": {
-      "status": "ready-for-validation-after-pypi-publish",
-      "notes": "PyPI package metadata is included for the official MCP Registry, but package publication is tracked separately."
-    }
-  }
+  ]
 }

--- a/src/mcp_server_python_docs/__init__.py
+++ b/src/mcp_server_python_docs/__init__.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 def _read_version() -> str:
     try:
-        return version("mcp-server-python-docs")
+        return version("python-docs-mcp-server")
     except PackageNotFoundError:
         pyproject_path = Path(__file__).resolve().parents[2] / "pyproject.toml"
         with pyproject_path.open("rb") as fh:

--- a/src/mcp_server_python_docs/__main__.py
+++ b/src/mcp_server_python_docs/__main__.py
@@ -79,7 +79,7 @@ def main(ctx: click.Context, show_version: bool) -> None:
     if show_version:
         from mcp_server_python_docs import __version__
 
-        click.echo(f"mcp-server-python-docs {__version__}", err=True)
+        click.echo(f"python-docs-mcp-server {__version__}", err=True)
         ctx.exit(0)
     if ctx.invoked_subcommand is None:
         ctx.invoke(serve)
@@ -404,7 +404,7 @@ def validate_corpus(db_path: str | None) -> None:
     if not target.exists():
         logger.error("Index not found at %s", target)
         logger.error(
-            "Run: mcp-server-python-docs build-index --versions %s",
+            "Run: python-docs-mcp-server build-index --versions %s",
             SUPPORTED_DOC_VERSIONS_CSV,
         )
         raise SystemExit(1)
@@ -488,7 +488,7 @@ def doctor() -> None:
 
         if plat.system() == "Linux" and plat.machine() == "x86_64":
             fts5_detail = (
-                "FTS5 unavailable -- pip install 'mcp-server-python-docs[pysqlite3]'"
+                "FTS5 unavailable -- pip install 'python-docs-mcp-server[pysqlite3]'"
             )
         else:
             fts5_detail = (
@@ -531,7 +531,7 @@ def doctor() -> None:
     index_detail = str(index_path)
     if not index_exists:
         index_detail += (
-            f" (not found -- run: mcp-server-python-docs build-index --versions "
+            f" (not found -- run: python-docs-mcp-server build-index --versions "
             f"{SUPPORTED_DOC_VERSIONS_CSV})"
         )
     else:
@@ -553,7 +553,7 @@ def doctor() -> None:
     results.append(("Disk space", disk_ok, disk_detail))
 
     # Print report (all to stderr for stdio hygiene)
-    click.echo("\nmcp-server-python-docs doctor\n", err=True)
+    click.echo("\npython-docs-mcp-server doctor\n", err=True)
     all_passed = True
     for probe_name, passed, detail in results:
         status = "PASS" if passed else "FAIL"

--- a/src/mcp_server_python_docs/errors.py
+++ b/src/mcp_server_python_docs/errors.py
@@ -1,4 +1,4 @@
-"""Error taxonomy for mcp-server-python-docs.
+"""Error taxonomy for python-docs-mcp-server.
 
 Named exceptions for predictable failure modes, mapped to MCP error responses.
 See build guide section 10.

--- a/src/mcp_server_python_docs/server.py
+++ b/src/mcp_server_python_docs/server.py
@@ -80,7 +80,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
 
         msg = (
             f"No index found at {index_path}\n"
-            f"Run: mcp-server-python-docs build-index --versions "
+            f"Run: python-docs-mcp-server build-index --versions "
             f"{SUPPORTED_DOC_VERSIONS_CSV}"
         )
         logger.error(msg)
@@ -219,7 +219,7 @@ PackageParam = Annotated[
 def create_server() -> FastMCP:
     """Create and configure the FastMCP server."""
     mcp = FastMCP(
-        "mcp-server-python-docs",
+        "python-docs-mcp-server",
         lifespan=app_lifespan,
     )
 

--- a/src/mcp_server_python_docs/services/package_docs.py
+++ b/src/mcp_server_python_docs/services/package_docs.py
@@ -45,7 +45,7 @@ Fetcher = Callable[[str, float], _HTTPResponse]
 def _default_fetcher(url: str, timeout: float) -> _HTTPResponse:
     req = Request(
         url,
-        headers={"Accept": "application/json", "User-Agent": "mcp-server-python-docs"},
+        headers={"Accept": "application/json", "User-Agent": "python-docs-mcp-server"},
     )
     return urlopen(req, timeout=timeout)
 

--- a/src/mcp_server_python_docs/storage/db.py
+++ b/src/mcp_server_python_docs/storage/db.py
@@ -100,7 +100,7 @@ def assert_fts5_available(conn: sqlite3.Connection) -> None:
         if system == "Linux" and machine == "x86_64":
             hint = (
                 "Install the pysqlite3-binary fallback:\n"
-                "  pip install 'mcp-server-python-docs[pysqlite3]'"
+                "  pip install 'python-docs-mcp-server[pysqlite3]'"
             )
         else:
             hint = (

--- a/src/mcp_server_python_docs/storage/schema.sql
+++ b/src/mcp_server_python_docs/storage/schema.sql
@@ -1,4 +1,4 @@
--- schema.sql — mcp-server-python-docs storage schema
+-- schema.sql — python-docs-mcp-server storage schema
 -- Version: Phase 2 (2026-04-16)
 --
 -- Design decisions:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""Shared test fixtures for mcp-server-python-docs."""
+"""Shared test fixtures for python-docs-mcp-server."""
 from __future__ import annotations
 
 import sqlite3

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -22,9 +22,9 @@ def test_slow_e2e_workflow_runs_installed_build_index() -> None:
     assert "python -m venv" in content
     assert "python -m pip install dist/" in content
     assert (
-        f"mcp-server-python-docs build-index --versions {SUPPORTED_VERSION_ARGS}"
+        f"python-docs-mcp-server build-index --versions {SUPPORTED_VERSION_ARGS}"
         in content
     )
-    assert "mcp-server-python-docs doctor" in content
-    assert "mcp-server-python-docs validate-corpus" in content
+    assert "python-docs-mcp-server doctor" in content
+    assert "python-docs-mcp-server validate-corpus" in content
     assert "actions/upload-artifact" in content

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -109,6 +109,13 @@ class TestPyprojectDeps:
         for dep_name in required_dep_names:
             assert dep_name in pyproject, f"Missing dependency: {dep_name}"
 
+    def test_classifiers_advertise_supported_python_versions(self):
+        """Classifiers must list every Python runtime the project supports."""
+        pyproject = (PROJECT_ROOT / "pyproject.toml").read_text()
+        for minor in (12, 13, 14):
+            classifier = f"Programming Language :: Python :: 3.{minor}"
+            assert classifier in pyproject, f"Missing classifier: {classifier}"
+
 
 class TestVersionFlag:
     """PKG-06: --version flag prints version."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -95,12 +95,10 @@ class TestWheelContent:
         )
         scripts = dict(parser.items("console_scripts"))
         target = "mcp_server_python_docs.__main__:main"
-        assert scripts.get(DIST_NAME) == target, (
-            f"Expected {DIST_NAME} -> {target}, got {scripts!r}"
-        )
-        assert scripts.get(LEGACY_CLI_NAME) == target, (
-            f"Expected {LEGACY_CLI_NAME} -> {target}, got {scripts!r}"
-        )
+        for cli_name in (DIST_NAME, LEGACY_CLI_NAME):
+            assert scripts.get(cli_name) == target, (
+                f"Expected {cli_name} -> {target}, got {scripts!r}"
+            )
 
 
 class TestPyprojectDeps:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -16,6 +16,8 @@ from pathlib import Path
 import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent
+DIST_NAME = "python-docs-mcp-server"
+LEGACY_CLI_NAME = "mcp-server-python-docs"
 
 
 def _uv_command() -> list[str]:
@@ -66,6 +68,14 @@ class TestWheelContent:
             + "\n".join(sorted(names))
         )
 
+    def test_wheel_metadata_uses_public_distribution_name(self, built_wheel):
+        """Wheel metadata must publish under the repo-aligned distribution name."""
+        with zipfile.ZipFile(built_wheel) as zf:
+            metadata_files = [n for n in zf.namelist() if n.endswith("METADATA")]
+            assert len(metadata_files) == 1
+            content = zf.read(metadata_files[0]).decode()
+        assert f"Name: {DIST_NAME}" in content
+
     def test_wheel_has_entry_point(self, built_wheel):
         """PKG-01: Wheel metadata declares the entry-point."""
         with zipfile.ZipFile(built_wheel) as zf:
@@ -75,7 +85,8 @@ class TestWheelContent:
             ]
             assert len(entry_point_files) == 1
             content = zf.read(entry_point_files[0]).decode()
-        assert "mcp-server-python-docs" in content
+        assert DIST_NAME in content
+        assert LEGACY_CLI_NAME in content
         assert "mcp_server_python_docs.__main__:main" in content
 
 
@@ -106,7 +117,7 @@ class TestVersionFlag:
         """__version__ stays in sync with installed package metadata."""
         import mcp_server_python_docs
 
-        assert mcp_server_python_docs.__version__ == version("mcp-server-python-docs")
+        assert mcp_server_python_docs.__version__ == version(DIST_NAME)
 
     def test_source_tree_import_without_installed_metadata(self, tmp_path: Path):
         """Source-tree import falls back to pyproject.toml when metadata is absent."""
@@ -130,7 +141,7 @@ class TestVersionFlag:
             f"stdout: {result.stdout!r}\n"
             f"stderr: {result.stderr!r}"
         )
-        assert result.stdout.strip() == version("mcp-server-python-docs")
+        assert result.stdout.strip() == version(DIST_NAME)
 
     def test_version_flag_output(self):
         """--version prints the installed package metadata version."""
@@ -142,7 +153,7 @@ class TestVersionFlag:
         )
         # Version output goes to stderr due to stdio hygiene
         combined = result.stdout + result.stderr
-        expected = version("mcp-server-python-docs")
+        expected = version(DIST_NAME)
         assert expected in combined, (
             f"Expected {expected!r} in output.\n"
             f"stdout: {result.stdout!r}\n"
@@ -173,7 +184,7 @@ class TestInstallability:
         )
         assert result.returncode == 0
         combined = result.stdout + result.stderr
-        assert version("mcp-server-python-docs") in combined
+        assert version(DIST_NAME) in combined
 
     def test_entry_point_module_exists(self):
         """The entry-point module is importable."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -77,17 +77,30 @@ class TestWheelContent:
         assert f"Name: {DIST_NAME}" in content
 
     def test_wheel_has_entry_point(self, built_wheel):
-        """PKG-01: Wheel metadata declares the entry-point."""
+        """PKG-01: Wheel metadata declares both console scripts, structurally."""
+        import configparser
+        import io
+
         with zipfile.ZipFile(built_wheel) as zf:
-            # Entry points are in the .dist-info/entry_points.txt
             entry_point_files = [
                 n for n in zf.namelist() if n.endswith("entry_points.txt")
             ]
             assert len(entry_point_files) == 1
             content = zf.read(entry_point_files[0]).decode()
-        assert DIST_NAME in content
-        assert LEGACY_CLI_NAME in content
-        assert "mcp_server_python_docs.__main__:main" in content
+
+        parser = configparser.ConfigParser()
+        parser.read_file(io.StringIO(content))
+        assert parser.has_section("console_scripts"), (
+            f"entry_points.txt missing [console_scripts]:\n{content}"
+        )
+        scripts = dict(parser.items("console_scripts"))
+        target = "mcp_server_python_docs.__main__:main"
+        assert scripts.get(DIST_NAME) == target, (
+            f"Expected {DIST_NAME} -> {target}, got {scripts!r}"
+        )
+        assert scripts.get(LEGACY_CLI_NAME) == target, (
+            f"Expected {LEGACY_CLI_NAME} -> {target}, got {scripts!r}"
+        )
 
 
 class TestPyprojectDeps:
@@ -127,15 +140,26 @@ class TestVersionFlag:
         assert mcp_server_python_docs.__version__ == version(DIST_NAME)
 
     def test_source_tree_import_without_installed_metadata(self, tmp_path: Path):
-        """Source-tree import falls back to pyproject.toml when metadata is absent."""
+        """Source-tree import falls back to pyproject.toml when metadata is absent.
+
+        Forces the fallback path by monkey-patching importlib.metadata.version
+        to raise PackageNotFoundError, since `-S` alone does not reliably
+        suppress editable-install dist-info discovery.
+        """
         env = os.environ.copy()
         env["PYTHONPATH"] = str(PROJECT_ROOT / "src")
+        prelude = (
+            "import importlib.metadata as m\n"
+            "def _raise(_):\n"
+            "    raise m.PackageNotFoundError\n"
+            "m.version = _raise\n"
+        )
         result = subprocess.run(
             [
                 sys.executable,
                 "-S",
                 "-c",
-                "import mcp_server_python_docs; print(mcp_server_python_docs.__version__)",
+                prelude + "import mcp_server_python_docs; print(mcp_server_python_docs.__version__)",
             ],
             capture_output=True,
             text=True,
@@ -148,7 +172,13 @@ class TestVersionFlag:
             f"stdout: {result.stdout!r}\n"
             f"stderr: {result.stderr!r}"
         )
-        assert result.stdout.strip() == version(DIST_NAME)
+        # The fallback reads pyproject.toml directly; assert it equals
+        # whatever pyproject currently declares (decoupled from installed metadata).
+        import tomllib
+        pyproject_version = tomllib.loads(
+            (PROJECT_ROOT / "pyproject.toml").read_text()
+        )["project"]["version"]
+        assert result.stdout.strip() == pyproject_version
 
     def test_version_flag_output(self):
         """--version prints the installed package metadata version."""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -159,7 +159,10 @@ class TestVersionFlag:
                 sys.executable,
                 "-S",
                 "-c",
-                prelude + "import mcp_server_python_docs; print(mcp_server_python_docs.__version__)",
+                prelude + (
+                    "import mcp_server_python_docs; "
+                    "print(mcp_server_python_docs.__version__)"
+                ),
             ],
             capture_output=True,
             text=True,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -418,6 +418,16 @@ class TestToolRegistration:
         assert "get_docs" in tool_names
         assert "list_versions" in tool_names
 
+    def test_create_server_identifies_as_dist_name(self):
+        """FastMCP server name must match the public distribution name."""
+        from mcp_server_python_docs.server import create_server
+
+        server = create_server()
+        # FastMCP exposes the constructor name via .name (mcp >= 1.27)
+        assert server.name == "python-docs-mcp-server", (
+            f"Expected FastMCP name 'python-docs-mcp-server', got {server.name!r}"
+        )
+
     def test_all_tools_have_annotations(self):
         from mcp_server_python_docs.server import create_server
 

--- a/uv.lock
+++ b/uv.lock
@@ -316,56 +316,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mcp-server-python-docs"
-version = "0.1.1"
-source = { editable = "." }
-dependencies = [
-    { name = "beautifulsoup4" },
-    { name = "click" },
-    { name = "markdownify" },
-    { name = "mcp" },
-    { name = "platformdirs" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
-    { name = "sphobjinv" },
-]
-
-[package.optional-dependencies]
-pysqlite3 = [
-    { name = "pysqlite3-binary" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "beautifulsoup4", specifier = ">=4.12,<5.0" },
-    { name = "click", specifier = ">=8.1.7,<9.0" },
-    { name = "markdownify", specifier = ">=0.14,<2.0" },
-    { name = "mcp", specifier = ">=1.27.0,<2.0.0" },
-    { name = "platformdirs", specifier = ">=4.0" },
-    { name = "pydantic", specifier = ">=2.0.0,<3.0" },
-    { name = "pysqlite3-binary", marker = "extra == 'pysqlite3'", specifier = ">=0.5.4" },
-    { name = "pyyaml", specifier = ">=6.0,<7.0" },
-    { name = "sphobjinv", specifier = ">=2.4,<3.0" },
-]
-provides-extras = ["pysqlite3"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "pyright", specifier = ">=1.1" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-asyncio", specifier = ">=0.23" },
-    { name = "ruff", specifier = ">=0.4" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -587,6 +537,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-docs-mcp-server"
+version = "0.1.1"
+source = { editable = "." }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "click" },
+    { name = "markdownify" },
+    { name = "mcp" },
+    { name = "platformdirs" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "sphobjinv" },
+]
+
+[package.optional-dependencies]
+pysqlite3 = [
+    { name = "pysqlite3-binary" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4", specifier = ">=4.12,<5.0" },
+    { name = "click", specifier = ">=8.1.7,<9.0" },
+    { name = "markdownify", specifier = ">=0.14,<2.0" },
+    { name = "mcp", specifier = ">=1.27.0,<2.0.0" },
+    { name = "platformdirs", specifier = ">=4.0" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0" },
+    { name = "pysqlite3-binary", marker = "extra == 'pysqlite3'", specifier = ">=0.5.4" },
+    { name = "pyyaml", specifier = ">=6.0,<7.0" },
+    { name = "sphobjinv", specifier = ">=2.4,<3.0" },
+]
+provides-extras = ["pysqlite3"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "ruff", specifier = ">=0.4" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #12.
Closes #13.
Closes #14.
Closes #19.
Closes #20.

- Renames the public distribution and primary CLI from `mcp-server-python-docs` to `python-docs-mcp-server`, while preserving `mcp-server-python-docs` as a legacy CLI alias.
- Updates README, contributor docs, integration testing docs, release docs, Slow E2E, MCP Registry metadata, and launch drafts to use the repo-aligned package name.
- Adds explicit post-PyPI README cleanup, MCP Registry submission, and launch-draft usage steps to the release checklist.
- Adds post-PyPI MCP client config examples, clarifies runtime Python 3.12+ vs indexed docs versions 3.10 through 3.14, and keeps `lookup_package_docs` scoped to package-declared PyPI metadata.

## Tests

- `python3 -m json.tool server.json`
- `uv run ruff check src/ tests/`
- `uv run pyright src/`
- `uv run pytest --tb=short -q` — 267 passed
- `uv build`
- `uv run python-docs-mcp-server --version` — `python-docs-mcp-server 0.1.1`
- `uv run mcp-server-python-docs --version` — `python-docs-mcp-server 0.1.1`

## Blockers / notes

- The README and launch drafts still keep clearly marked pre-PyPI GitHub-source instructions until the first PyPI release is live.
- `server.json` now points at the final PyPI identifier, but official MCP Registry submission should still wait until the PyPI smoke test passes.
- No external submissions or posts were made: no MCP Registry submission, no Reddit post, no HN post, no directory/list submissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release checklist/instructions for v0.1.1, expanded onboarding (30‑second demo), pre/post‑PyPI install & troubleshooting, and added launch drafts and rollout guidance.
* **User-Facing**
  * Renamed the public package/CLI to "python-docs-mcp-server" in docs, examples, install instructions, and CLI output.
* **Tests**
  * Added/updated packaging and service tests to expect the new distribution name and validate entrypoints/version.
* **New Files**
  * Added server metadata and launch post drafts for publication guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Coherence fix-pack (post-review)

Addresses findings from the deep coherence/consistency review of the original PR:

- **C1 + I1:** Widened `<!-- PRE-PYPI -->` markers to enclose full transient sections (heading + lead-in sentence + code). The committed cleanup regex now catches every transient block. RELEASE.md cleanup checklist references a single perl one-liner for a mechanical cleanup pass. Also added a post-review polish: `### After PyPI publishing` heading in First run + post-cleanup intros for Diagnostics.
- **I3:** Hardened `test_source_tree_import_without_installed_metadata` by monkey-patching `importlib.metadata.version` to raise `PackageNotFoundError`. Previously the test passed for the wrong reason (installed metadata coincidentally equaled pyproject). Verified via mutation: setting `BOGUS` in `__init__.py` now produces a clear failure.
- **I4:** Added `Programming Language :: Python :: 3.14` classifier + regression test asserting classifier presence for 3.12, 3.13, 3.14.
- **I5:** Reconciled Show HN `build-index` to the full 5-version list. AGENTS.md's `3.12,3.13` deliberately preserved as the contributor quick-build.
- **I6:** Added `### Migrating from the pre-rename CLI` troubleshooting subsection explaining the rename and the `uvx` PyPI-name resolution behavior.
- **M1:** Added `test_create_server_identifies_as_dist_name` asserting `FastMCP("python-docs-mcp-server", ...)`. Verified via mutation.
- **M2:** Replaced substring assertions on `entry_points.txt` with `configparser` parsing that verifies each console script is bound to `mcp_server_python_docs.__main__:main`. Verified via mutation.

Fix-pack commits land on top of the original PR; full plan and reviewer transcripts at `docs/superpowers/plans/2026-05-11-pr22-coherence-fixes.md`.
