### PR TITLE
chore: rename repo URLs ayhammouda/python-docs-mcp-server -> python-stdlib-mcp

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,7 +8,7 @@ Before the first release, configure PyPI Trusted Publishing:
 2. Add a new pending publisher:
    - **PyPI project name**: `python-docs-mcp-server`
    - **Owner**: your GitHub username or org
-   - **Repository**: `python-docs-mcp-server`
+   - **Repository**: `python-stdlib-mcp`
    - **Workflow name**: `release.yml`
    - **Environment name**: `pypi`
 3. In the GitHub repo, go to Settings > Environments
@@ -96,7 +96,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 - [ ] PyPI pending publisher configured at https://pypi.org/manage/account/publishing/:
   - PyPI project name: `python-docs-mcp-server`
   - Owner: `<your-github-username>`
-  - Repository: `python-docs-mcp-server`
+  - Repository: `python-stdlib-mcp`
   - Workflow name: `release.yml`
   - Environment name: `pypi`
 - [ ] GitHub environment `pypi` created in repo Settings > Environments

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -51,7 +51,7 @@ versions 3.10 through 3.14.
    ```
 
 4. Monitor the release workflow at:
-   https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
+   https://github.com/<owner>/python-stdlib-mcp/actions/workflows/release.yml
 
 5. Verify the package on PyPI:
    https://pypi.org/project/python-docs-mcp-server/0.1.2/
@@ -76,7 +76,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 
 ### Pre-Release Verification
 
-- [ ] All CI tests green on main: check https://github.com/<owner>/python-docs-mcp-server/actions/workflows/ci.yml
+- [ ] All CI tests green on main: check https://github.com/<owner>/python-stdlib-mcp/actions/workflows/ci.yml
 - [ ] Local test suite passes:
   ```bash
   uv run pytest --tb=short -q
@@ -118,7 +118,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   ```bash
   git push origin v0.1.1
   ```
-- [ ] Monitor the workflow run: https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
+- [ ] Monitor the workflow run: https://github.com/<owner>/python-stdlib-mcp/actions/workflows/release.yml
 - [ ] Verify all three jobs pass: `build` -> `publish` -> `github-release`
 
 ### Post-Release Verification (SHIP-06)
@@ -166,7 +166,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
     examples
 - [ ] Verify `README.md` has no temporary pre-release install artifacts:
   ```bash
-  rg -n 'PRE[-]PYPI|Before PyPI publishing|Until the first PyPI|After PyPI publishing|git\\+https://github.com/.*/python-docs-mcp-server' README.md
+  rg -n 'PRE[-]PYPI|Before PyPI publishing|Until the first PyPI|After PyPI publishing|git\\+https://github.com/.*/python-stdlib-mcp' README.md
   ```
   The command should return no output.
 - [ ] Review `docs/launch/` so no public launch copy still asks users to install

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # python-docs-mcp-server
 
-<!-- mcp-name: io.github.ayhammouda/python-docs-mcp-server -->
+<!-- mcp-name: io.github.ayhammouda/python-stdlib-mcp -->
 
 **For AI coding agents writing Python, `python-docs-mcp-server` is the canonical Python stdlib oracle: exact symbols, exact sections, exact versions — offline, *always free, always MIT*, token-frugal.**
 
-[![CI](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/ci.yml)
-[![Security Audit](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/security.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/security.yml)
-[![CodeQL](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/codeql.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ayhammouda/python-docs-mcp-server/badge)](https://scorecard.dev/viewer/?uri=github.com/ayhammouda/python-docs-mcp-server)
-[![python-docs-mcp-server MCP server](https://glama.ai/mcp/servers/ayhammouda/python-docs-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ayhammouda/python-docs-mcp-server)
-[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-v0.1.4-0f766e)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ayhammouda%2Fpython-docs-mcp-server)
+[![CI](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/ci.yml)
+[![Security Audit](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/security.yml/badge.svg)](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/security.yml)
+[![CodeQL](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/codeql.yml/badge.svg)](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ayhammouda/python-stdlib-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/ayhammouda/python-stdlib-mcp)
+[![python-docs-mcp-server MCP server](https://glama.ai/mcp/servers/ayhammouda/python-stdlib-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ayhammouda/python-stdlib-mcp)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-v0.1.4-0f766e)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ayhammouda%2Fpython-stdlib-mcp)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![No API Keys](https://img.shields.io/badge/API%20keys-none-success)](#why-use-it)
@@ -76,7 +76,7 @@ trimmed to the section that matters.
 Local source smoke test until the PyPI package is published:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
+uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
@@ -88,7 +88,7 @@ uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-d
 Until the first PyPI release is published, run from GitHub:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
+uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
@@ -119,7 +119,7 @@ Build the local documentation index:
 
 <!-- PRE-PYPI: remove the GitHub-source build-index command and the "After PyPI publishing" lead-in after the first PyPI publish; the post-PyPI code fence below survives -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
 
 After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
@@ -163,7 +163,7 @@ Add this to your Claude Desktop configuration file:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
+        "git+https://github.com/ayhammouda/python-stdlib-mcp.git",
         "python-docs-mcp-server"
       ]
     }
@@ -200,7 +200,7 @@ global settings):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
+        "git+https://github.com/ayhammouda/python-stdlib-mcp.git",
         "python-docs-mcp-server"
       ]
     }
@@ -230,7 +230,7 @@ Add this to `.codex/config.toml`:
 ```toml
 [mcp_servers.python-docs]
 command = "uvx"
-args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "python-docs-mcp-server"]
+args = ["--from", "git+https://github.com/ayhammouda/python-stdlib-mcp.git", "python-docs-mcp-server"]
 ```
 
 After PyPI publishing, use:
@@ -323,7 +323,7 @@ search, or silently fall back to unofficial community mirrors.
 Before PyPI publishing, run `doctor` from the GitHub source package:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server doctor
+uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server doctor
 ```
 
 After PyPI publishing:
@@ -343,7 +343,7 @@ Before PyPI publishing, validate an existing index from the GitHub source
 package:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server validate-corpus
+uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server validate-corpus
 ```
 
 After PyPI publishing:
@@ -442,7 +442,7 @@ access. If `uvx` is not found, specify the full path in your config:
       "command": "C:\\Users\\YOU\\.local\\bin\\uvx.exe",
       "args": [
         "--from",
-        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
+        "git+https://github.com/ayhammouda/python-stdlib-mcp.git",
         "python-docs-mcp-server"
       ]
     }

--- a/server.json
+++ b/server.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.ayhammouda/python-docs-mcp-server",
+  "name": "io.github.ayhammouda/python-stdlib-mcp",
   "description": "The canonical Python stdlib oracle for AI coding agents. Exact symbols, exact sections, exact versions — offline, always free, always MIT, token-frugal.",
   "title": "Python Docs MCP Server",
-  "websiteUrl": "https://github.com/ayhammouda/python-docs-mcp-server",
+  "websiteUrl": "https://github.com/ayhammouda/python-stdlib-mcp",
   "repository": {
-    "url": "https://github.com/ayhammouda/python-docs-mcp-server",
+    "url": "https://github.com/ayhammouda/python-stdlib-mcp",
     "source": "github"
   },
   "version": "0.1.4",


### PR DESCRIPTION
## Summary

PR #2 of 6 in the v0.1.5 launch wave (per [CHANGE-REQUEST-v0.1.5-launch.md](./CHANGE-REQUEST-v0.1.5-launch.md), §F).

In-repo URL rename to prepare for the GitHub repo rename (`python-docs-mcp-server` → `python-stdlib-mcp`, locked decision §9.2). The PyPI package name **stays** `python-docs-mcp-server` through v0.1.5 to avoid stacking two rename migrations.

## Surface area

**3 files, 24+/24-:**
- `README.md` — 16 URL refs (CI/Security/CodeQL badges, OpenSSF Scorecard, Glama badge, MCP Registry badge, mcp-name comment, install scaffolds + MCP client config snippets across all PRE-PYPI fenced blocks)
- `server.json` — 3 fields (`name`, `websiteUrl`, `repository.url`); `identifier` (PyPI name) **unchanged**
- `.github/RELEASE.md` — 3 `<owner>/python-docs-mcp-server` template URLs + 1 regex-literal pattern in the PRE-PYPI scaffolding validation script

## What stays unchanged (audit confirmed)

- `pyproject.toml` `name = "python-docs-mcp-server"` (PyPI package name)
- `server.json` `"identifier": "python-docs-mcp-server"` (PyPI registry identifier)
- All `uvx python-docs-mcp-server` and `pipx install python-docs-mcp-server` CLI invocations in README, CONTRIBUTING, RELEASE, INTEGRATION-TEST
- `src/` and `tests/` are untouched

## Hard sequencing

This PR **must merge before tagging v0.1.5** (per plan critical path `F6 → B5`); otherwise the release artifacts and PyPI metadata will reference the now-redirected old repo URL. The GitHub redirect handles `git clone`, but the canonical metadata in PyPI/MCP Registry should point at the new URL from v0.1.5's first publish.

## Manual follow-ups (post-merge, not in this PR)

- Rename repo on GitHub: Settings → Repository name → `python-stdlib-mcp` (F3)
- Update GitHub About text + topics + social preview (A4/F4)
- Verify Glama and OpenSSF Scorecard URLs resolve at new path (F5; Scorecard re-runs Mondays per `.github/workflows/scorecard.yml`)

## Conflict expectations

Touches the same README region as [apps#25 (positioning)](https://github.com/ayhammouda/python-docs-mcp-server/pull/25). A small rebase will be needed when the second of these merges. Both changes are surgical to different lines/substrings so conflicts are mechanical.

## Test plan

- [ ] `git grep 'ayhammouda/python-docs-mcp-server'` returns 0 matches
- [ ] `git grep 'io.github.ayhammouda%2Fpython-docs-mcp-server'` returns 0 matches
- [ ] PyPI package name preserved: `name = "python-docs-mcp-server"` in pyproject.toml; `"identifier": "python-docs-mcp-server"` in server.json
- [ ] `server.json` parses as valid JSON
- [ ] CI green (ci.yml, security.yml, codeql.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions, examples, badges, diagnostics, and client configuration across Windows, macOS, and Linux to point to the renamed repository (python-stdlib-mcp).

* **Chores**
  * Updated server metadata, release workflow/checklist links, and release validation references to reflect the new project name and repository URLs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/26)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->