### PR TITLE
revert: drop GitHub repo rename from v0.1.5 scope (keeps python-docs-mcp-server)

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -8,7 +8,7 @@ Before the first release, configure PyPI Trusted Publishing:
 2. Add a new pending publisher:
    - **PyPI project name**: `python-docs-mcp-server`
    - **Owner**: your GitHub username or org
-   - **Repository**: `python-stdlib-mcp`
+   - **Repository**: `python-docs-mcp-server`
    - **Workflow name**: `release.yml`
    - **Environment name**: `pypi`
 3. In the GitHub repo, go to Settings > Environments
@@ -51,7 +51,7 @@ versions 3.10 through 3.14.
    ```
 
 4. Monitor the release workflow at:
-   https://github.com/<owner>/python-stdlib-mcp/actions/workflows/release.yml
+   https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
 
 5. Verify the package on PyPI:
    https://pypi.org/project/python-docs-mcp-server/0.1.2/
@@ -76,7 +76,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 
 ### Pre-Release Verification
 
-- [ ] All CI tests green on main: check https://github.com/<owner>/python-stdlib-mcp/actions/workflows/ci.yml
+- [ ] All CI tests green on main: check https://github.com/<owner>/python-docs-mcp-server/actions/workflows/ci.yml
 - [ ] Local test suite passes:
   ```bash
   uv run pytest --tb=short -q
@@ -96,7 +96,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
 - [ ] PyPI pending publisher configured at https://pypi.org/manage/account/publishing/:
   - PyPI project name: `python-docs-mcp-server`
   - Owner: `<your-github-username>`
-  - Repository: `python-stdlib-mcp`
+  - Repository: `python-docs-mcp-server`
   - Workflow name: `release.yml`
   - Environment name: `pypi`
 - [ ] GitHub environment `pypi` created in repo Settings > Environments
@@ -118,7 +118,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   ```bash
   git push origin v0.1.1
   ```
-- [ ] Monitor the workflow run: https://github.com/<owner>/python-stdlib-mcp/actions/workflows/release.yml
+- [ ] Monitor the workflow run: https://github.com/<owner>/python-docs-mcp-server/actions/workflows/release.yml
 - [ ] Verify all three jobs pass: `build` -> `publish` -> `github-release`
 
 ### Post-Release Verification (SHIP-06)
@@ -166,7 +166,7 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
     examples
 - [ ] Verify `README.md` has no temporary pre-release install artifacts:
   ```bash
-  rg -n 'PRE[-]PYPI|Before PyPI publishing|Until the first PyPI|After PyPI publishing|git\\+https://github.com/.*/python-stdlib-mcp' README.md
+  rg -n 'PRE[-]PYPI|Before PyPI publishing|Until the first PyPI|After PyPI publishing|git\\+https://github.com/.*/python-docs-mcp-server' README.md
   ```
   The command should return no output.
 - [ ] Review `docs/launch/` so no public launch copy still asks users to install

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -3,7 +3,7 @@
 ## Current
 
 - **v0.1.4** — shipped (pre-PyPI; installed via `uvx --from git+…`)
-- **v0.1.5** — in progress. Five coordinated workstreams: positioning lockdown ("canonical Python stdlib oracle for AI coding agents — always free, always MIT, token-frugal"); first PyPI publish via Trusted Publishing; GitHub repo rename to `python-stdlib-mcp` (PyPI package name stays `python-docs-mcp-server`); benchmark harness against competing docs MCPs; coordinated launch post on a personal blog, dev.to, and Show HN.
+- **v0.1.5** — in progress. Four coordinated workstreams: positioning lockdown ("canonical Python stdlib oracle for AI coding agents — always free, always MIT, token-frugal"); first PyPI publish via Trusted Publishing; benchmark harness against competing docs MCPs; coordinated launch post on a personal blog, dev.to, and Show HN. (Note: the GitHub repo rename to `python-stdlib-mcp` originally planned for v0.1.5 was dropped on 2026-05-14 — the repo and PyPI package keep the `python-docs-mcp-server` name.)
 
 ## Backlog (post-v0.1.5)
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # python-docs-mcp-server
 
-<!-- mcp-name: io.github.ayhammouda/python-stdlib-mcp -->
+<!-- mcp-name: io.github.ayhammouda/python-docs-mcp-server -->
 
 **For AI coding agents writing Python, `python-docs-mcp-server` is the canonical Python stdlib oracle: exact symbols, exact sections, exact versions — offline, *always free, always MIT*, token-frugal.**
 
-[![CI](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/ci.yml)
-[![Security Audit](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/security.yml/badge.svg)](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/security.yml)
-[![CodeQL](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/codeql.yml/badge.svg)](https://github.com/ayhammouda/python-stdlib-mcp/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ayhammouda/python-stdlib-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/ayhammouda/python-stdlib-mcp)
-[![python-docs-mcp-server MCP server](https://glama.ai/mcp/servers/ayhammouda/python-stdlib-mcp/badges/score.svg)](https://glama.ai/mcp/servers/ayhammouda/python-stdlib-mcp)
-[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-v0.1.4-0f766e)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ayhammouda%2Fpython-stdlib-mcp)
+[![CI](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/ci.yml)
+[![Security Audit](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/security.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/security.yml)
+[![CodeQL](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/codeql.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ayhammouda/python-docs-mcp-server/badge)](https://scorecard.dev/viewer/?uri=github.com/ayhammouda/python-docs-mcp-server)
+[![python-docs-mcp-server MCP server](https://glama.ai/mcp/servers/ayhammouda/python-docs-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ayhammouda/python-docs-mcp-server)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-v0.1.4-0f766e)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ayhammouda%2Fpython-docs-mcp-server)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![No API Keys](https://img.shields.io/badge/API%20keys-none-success)](#why-use-it)
@@ -76,7 +76,7 @@ trimmed to the section that matters.
 Local source smoke test until the PyPI package is published:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
@@ -88,7 +88,7 @@ uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-m
 Until the first PyPI release is published, run from GitHub:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server --version
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server --version
 ```
 <!-- /PRE-PYPI -->
 
@@ -119,7 +119,7 @@ Build the local documentation index:
 
 <!-- PRE-PYPI: remove the GitHub-source build-index command and the "After PyPI publishing" lead-in after the first PyPI publish; the post-PyPI code fence below survives -->
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server build-index --versions 3.10,3.11,3.12,3.13,3.14
 ```
 
 After PyPI publishing, `uvx python-docs-mcp-server build-index ...` is enough.
@@ -163,7 +163,7 @@ Add this to your Claude Desktop configuration file:
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/ayhammouda/python-stdlib-mcp.git",
+        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
         "python-docs-mcp-server"
       ]
     }
@@ -200,7 +200,7 @@ global settings):
       "command": "uvx",
       "args": [
         "--from",
-        "git+https://github.com/ayhammouda/python-stdlib-mcp.git",
+        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
         "python-docs-mcp-server"
       ]
     }
@@ -230,7 +230,7 @@ Add this to `.codex/config.toml`:
 ```toml
 [mcp_servers.python-docs]
 command = "uvx"
-args = ["--from", "git+https://github.com/ayhammouda/python-stdlib-mcp.git", "python-docs-mcp-server"]
+args = ["--from", "git+https://github.com/ayhammouda/python-docs-mcp-server.git", "python-docs-mcp-server"]
 ```
 
 After PyPI publishing, use:
@@ -323,7 +323,7 @@ search, or silently fall back to unofficial community mirrors.
 Before PyPI publishing, run `doctor` from the GitHub source package:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server doctor
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server doctor
 ```
 
 After PyPI publishing:
@@ -343,7 +343,7 @@ Before PyPI publishing, validate an existing index from the GitHub source
 package:
 
 ```bash
-uvx --from git+https://github.com/ayhammouda/python-stdlib-mcp.git python-docs-mcp-server validate-corpus
+uvx --from git+https://github.com/ayhammouda/python-docs-mcp-server.git python-docs-mcp-server validate-corpus
 ```
 
 After PyPI publishing:
@@ -442,7 +442,7 @@ access. If `uvx` is not found, specify the full path in your config:
       "command": "C:\\Users\\YOU\\.local\\bin\\uvx.exe",
       "args": [
         "--from",
-        "git+https://github.com/ayhammouda/python-stdlib-mcp.git",
+        "git+https://github.com/ayhammouda/python-docs-mcp-server.git",
         "python-docs-mcp-server"
       ]
     }

--- a/server.json
+++ b/server.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.ayhammouda/python-stdlib-mcp",
+  "name": "io.github.ayhammouda/python-docs-mcp-server",
   "description": "The canonical Python stdlib oracle for AI coding agents. Exact symbols, exact sections, exact versions — offline, always free, always MIT, token-frugal.",
   "title": "Python Docs MCP Server",
-  "websiteUrl": "https://github.com/ayhammouda/python-stdlib-mcp",
+  "websiteUrl": "https://github.com/ayhammouda/python-docs-mcp-server",
   "repository": {
-    "url": "https://github.com/ayhammouda/python-stdlib-mcp",
+    "url": "https://github.com/ayhammouda/python-docs-mcp-server",
     "source": "github"
   },
   "version": "0.1.4",


### PR DESCRIPTION
## Summary

Reverts [apps#26](https://github.com/ayhammouda/python-docs-mcp-server/pull/26) — the GitHub repo rename to `python-stdlib-mcp` originally planned in CR §9.2.

Per owner decision on 2026-05-14, the repo and the PyPI package both keep the existing `python-docs-mcp-server` name. The rename was being pursued for naming consistency, but the owner decided the cost (Trusted Publisher reconfig, redirect dependency, broken external links until external indexers re-crawl) outweighed the benefit.

## What this changes

- **Reverts** all in-repo URL changes from `ayhammouda/python-stdlib-mcp` → back to `ayhammouda/python-docs-mcp-server` (in `README.md`, `server.json`, and `.github/RELEASE.md`).
- **Updates** [`.planning/ROADMAP.md`](.planning/ROADMAP.md) to reflect the four remaining v0.1.5 workstreams (positioning, PyPI publish, benchmark harness, launch post) — dropping the rename row.

## What this does NOT change

- **Positioning sentence** in README hero, glama.json, server.json, pyproject.toml descriptions — kept intact from PR #25.
- **"Always free, always MIT" anchor** — kept across all positioning surfaces.
- **Phase 9/10/11 backlog** from PR #27 — unaffected (none of those CONTEXTs reference the repo name).
- **PyPI Trusted Publisher** — no manual update needed; the existing config with Repository: `python-docs-mcp-server` is already correct.
- **`mcp_server_python_docs` Python package name** — unchanged.

## Why now

The CR §9.2 decision was reversed before:
- The GitHub repo was actually renamed (verified: `https://github.com/ayhammouda/python-stdlib-mcp` returns 404)
- The PyPI Trusted Publisher Repository field was updated
- The v0.1.5 tag was cut

Reverting now keeps the launch wave coherent and avoids stale references to a name that never shipped externally.

## Test plan

- [ ] `git grep 'python-stdlib-mcp'` returns only the historical mention in `.planning/ROADMAP.md:6` (explaining the dropped decision)
- [ ] `git grep 'ayhammouda/python-docs-mcp-server'` shows all the badge and install-scaffold URLs back to the existing repo name
- [ ] `server.json` `description` still carries the canonical-source positioning sentence (PR #25's contribution preserved)
- [ ] `server.json` parses as valid JSON
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and MCP client configuration examples to reflect current server references.
  * Refreshed release process documentation with updated repository information.
  * Updated project roadmap to reflect current workstream scope.

* **Chores**
  * Updated server metadata and identity references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/28)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->