### PR TITLE
fix(server.json): shorten description to ≤100 chars for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.ayhammouda/python-docs-mcp-server",
-  "description": "The canonical Python stdlib oracle for AI coding agents. Exact symbols, exact sections, exact versions — offline, always free, always MIT, token-frugal.",
+  "description": "The canonical Python stdlib oracle for AI coding agents — always free, always MIT, token-frugal.",
   "title": "Python Docs MCP Server",
   "websiteUrl": "https://github.com/ayhammouda/python-docs-mcp-server",
   "repository": {


### PR DESCRIPTION
## Summary

Hotfix for the MCP Registry validation failure surfaced during the v0.1.5 release pipeline.

## Context

The v0.1.5 release ran successfully on PyPI ([live with attestations](https://pypi.org/project/python-docs-mcp-server/0.1.5/)) but the `publish-mcp-registry` job in [release run #25876196215](https://github.com/ayhammouda/python-docs-mcp-server/actions/runs/25876196215) failed at the `Validate server.json` step:

```
Error: validation failed: server returned status 422
{"errors":[{"message":"expected length <= 100","location":"body.description","value":"The canonical Python stdlib oracle for AI coding agents. Exact symbols, exact sections, exact versions — offline, always free, always MIT, token-frugal."}]}
```

MCP Registry's schema enforces `body.description ≤ 100 chars`. PyPI has no such limit (summary cap is 512), so v0.1.5 published successfully on PyPI with the 152-char description, but MCP Registry rejected it. The downstream `github-release` job was blocked; I created the v0.1.5 GH Release manually from local dist artifacts.

## The fix

Shorten `server.json` `description` from 152 to **96 chars**, preserving all three locked anchor phrases per `.planning/POSITIONING.md`:

```
"The canonical Python stdlib oracle for AI coding agents — always free, always MIT, token-frugal."
```

Anchor coverage verified:
- ✅ `canonical Python stdlib oracle`
- ✅ `always free, always MIT`
- ✅ `token-frugal`

**Pre-validated against MCP Registry's actual endpoint:**
```
$ ./mcp-publisher validate server.json
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

## Not touched

- `pyproject.toml` description stays at 154 chars. PyPI's 512-char summary cap means the longer form is fine for the PyPI display; the surface-specific length contract in POSITIONING.md is intentional.
- README hero positioning sentence stays at full length (152 chars). Not constrained by any schema; the longer form is the canonical "use verbatim" copy.

## Next step

With this fix on `main`, the next tag push will publish to MCP Registry successfully. Whether to ship v0.1.6 now as a patch release (purely metadata; same wheel content) or fold this into the natural next release is a separate call — discussed in the post-merge follow-up.

## Test plan

- [x] `mcp-publisher validate server.json` → valid (run locally with the actual mcp-publisher binary against the real registry endpoint)
- [ ] CI green
- [x] Anchor phrases preserved
- [x] JSON parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project description to emphasize core capabilities and key values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/30)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->