### PR TITLE
chore: v0.1.6 — MCP Registry hotfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to `python-docs-mcp-server` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6] — 2026-05-14
+
+### Fixed
+
+- **MCP Registry publish** — `server.json` `description` shortened from 152 to 96 characters to comply with MCP Registry's schema constraint (`body.description ≤ 100 chars`). The v0.1.5 release succeeded on PyPI (no such limit) but the `publish-mcp-registry` workflow job failed validation; v0.1.5 therefore never reached MCP Registry. v0.1.6 ships the same wheel content as v0.1.5 with the corrected `server.json` so MCP Registry catches up. All three locked anchor phrases — *canonical Python stdlib oracle*, *always free, always MIT*, *token-frugal* — are preserved in the shortened form per `.planning/POSITIONING.md`'s adapt-for-length contract.
+
+### Notes
+
+- `pyproject.toml` `description` (154 chars) is unchanged; PyPI's 512-char summary cap is unaffected.
+- The locked README hero positioning sentence (the long, "use verbatim" form) is unchanged.
+
 ## [0.1.5] — 2026-05-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python-docs-mcp-server"
-version = "0.1.5"
+version = "0.1.6"
 description = "The canonical Python stdlib oracle for AI coding agents — exact symbols, exact sections, exact versions, offline, always free, always MIT, token-frugal."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/ayhammouda/python-docs-mcp-server",
     "source": "github"
   },
-  "version": "0.1.5",
+  "version": "0.1.6",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "python-docs-mcp-server",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "python-docs-mcp-server"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Patch release on top of v0.1.5 to unblock MCP Registry publication.

[v0.1.5](https://pypi.org/project/python-docs-mcp-server/0.1.5/) published successfully to PyPI with attestations, but the `publish-mcp-registry` job in [release run #25876196215](https://github.com/ayhammouda/python-docs-mcp-server/actions/runs/25876196215) failed at the `Validate server.json` step:

```
expected length <= 100   location: body.description   (value was 152 chars)
```

[apps#30](https://github.com/ayhammouda/python-docs-mcp-server/pull/30) shortened `server.json` description to 96 chars on `main` and pre-validated it with the actual `mcp-publisher` binary against the live registry endpoint:

```
$ ./mcp-publisher validate server.json
Validating against https://registry.modelcontextprotocol.io...
✅ server.json is valid
```

v0.1.6 ships the corrected `server.json` so MCP Registry catches up. Same wheel content as v0.1.5; the only functional difference is the registry metadata.

## Changes

- Bump `0.1.5 → 0.1.6` in the three lockstep files:
  - `pyproject.toml:7`
  - `server.json:11` (top-level)
  - `server.json:17` (`packages[0].version`)
  - `uv.lock` (regenerated)
- `CHANGELOG.md` v0.1.6 entry under `### Fixed`

## Verified locally

- ✅ `uv build` produces `python_docs_mcp_server-0.1.6-py3-none-any.whl` + `.tar.gz`
- ✅ Clean-venv install: `python-docs-mcp-server --version` reports `0.1.6`
- ✅ `mcp-publisher validate server.json` against the real registry endpoint: VALID
- ✅ All three locked anchor phrases (`canonical Python stdlib oracle` / `always free, always MIT` / `token-frugal`) preserved in the 96-char description

## What lands after merge + tag

Tagging `v0.1.6` triggers `.github/workflows/release.yml`:
1. **build** — verifies version triple lockstep, runs lint/type/test, builds wheel + sdist
2. **publish** — PyPI publish (Trusted Publishing + Sigstore)
3. **publish-mcp-registry** — this time validation passes; MCP Registry receives v0.1.6 metadata
4. **github-release** — creates GH Release v0.1.6 with the dist artifacts attached

## Test plan

- [x] mcp-publisher validate against live registry endpoint → ✅
- [x] uv build + clean-venv install + version check
- [ ] CI green on PR
- [ ] After merge + tag: all 4 release.yml jobs green
- [ ] After release: `uvx --refresh python-docs-mcp-server --version` returns `0.1.6` from a clean shell
- [ ] MCP Registry shows v0.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the server description field in configuration metadata to comply with registry validation schema requirements and character length constraints.

* **Documentation**
  * Updated the changelog to document the version 0.1.6 release, detailing configuration corrections and the preservation of documentation elements.

* **Chores**
  * Released version 0.1.6 with updated version numbers across project configuration files, server manifest, and package metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/31)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->