### PR TITLE
docs(release): add mcp-publisher validate pre-tag check + backfill phase issue links

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -85,6 +85,12 @@ Complete these steps in order. Each step has a checkbox -- do not skip ahead.
   ```bash
   grep '^version' pyproject.toml
   ```
+- [ ] `server.json` validates against the live MCP Registry schema. MCP Registry enforces stricter limits than PyPI (e.g. `description ≤ 100 chars`); validating before the tag prevents a half-published release (PyPI succeeds while MCP Registry rejects, as happened on v0.1.5 → recovered in v0.1.6):
+  ```bash
+  curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+  ./mcp-publisher validate server.json
+  ```
+  Must report `✅ server.json is valid`. If validation fails, shorten the `server.json` `description` on `main` before tagging (the `pyproject.toml` description is unbounded by this constraint and can stay longer).
 - [ ] Integration tests from `.github/INTEGRATION-TEST.md` are complete and signed off
 - [ ] Doctor subcommand passes:
   ```bash

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -9,9 +9,9 @@
 
 | Phase | Title | Tool surface | Issue |
 |-------|-------|--------------|-------|
-| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | #TBD-link-after-PR-merges |
-| 10 | `whatsnew_for_version(version)` | New MCP tool | #TBD-link-after-PR-merges |
-| 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | #TBD-link-after-PR-merges |
+| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) |
+| 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) |
+| 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) |
 
 These are planned, not committed. Phase CONTEXTs at [`phases/09-compare-versions/`](phases/09-compare-versions/09-CONTEXT.md), [`phases/10-whatsnew/`](phases/10-whatsnew/10-CONTEXT.md), [`phases/11-detect-venv/`](phases/11-detect-venv/11-CONTEXT.md). Implementation kickoff requires `/gsd-plan-phase 0X`.
 


### PR DESCRIPTION
## Summary

Two small housekeeping items after the v0.1.5 → v0.1.6 release arc:

### 1. `.github/RELEASE.md` — new pre-tag check

The Pre-Release Verification checklist now includes:

> \`\`\`bash
> curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_..." | tar xz mcp-publisher
> ./mcp-publisher validate server.json
> \`\`\`
> Must report \`✅ server.json is valid\`.

**Why:** v0.1.5 was a half-publish — PyPI succeeded (no description-length limit; 152-char description accepted) but MCP Registry rejected validation (its schema caps `description ≤ 100 chars`). The recovery took an extra v0.1.6 patch release. A 10-second local validate before tagging would have caught it.

### 2. `.planning/ROADMAP.md` — backfill phase issue links

The post-v0.1.5 backlog table now links the three phase rows to live GitHub issues:

| Phase | Issue |
|---|---|
| 09 \`compare_versions\` | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) |
| 10 \`whatsnew_for_version\` | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) |
| 11 \`detect_python_version\` v2 | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) |

All three issues use the new \`phase-plan\` label + \`help wanted\` + \`enhancement\`, with the corresponding CONTEXT.md content as the issue body.

## Out of scope

The RELEASE.md still has stale per-version content (header says "v0.1.1 Release Checklist", grep checks for \`0.1.1\` in pyproject.toml, etc). Generalizing those to be version-agnostic is a worthwhile cleanup but separate from this fix-and-backfill PR. Suggest a follow-up issue if desired.

## Test plan

- [x] \`./mcp-publisher validate server.json\` on this branch → \`✅ server.json is valid\` (verified locally against the live registry endpoint before commit)
- [x] Issue links resolve: #32, #33, #34
- [ ] CI green
- [ ] Reviewer can follow the new pre-tag check successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release process documentation with server validation requirements during releases.
  * Updated roadmap with specific tracking references for upcoming features and enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/35)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->