### PR TITLE
feat: add compare_versions MCP tool (Phase 09)

### DIFF
--- a/.github/INTEGRATION-TEST.md
+++ b/.github/INTEGRATION-TEST.md
@@ -38,8 +38,10 @@ npx @modelcontextprotocol/inspector uv --directory . run python-docs-mcp-server
 - [ ] Confirm the tool list includes:
   - `search_docs`
   - `get_docs`
+  - `lookup_package_docs`
   - `list_versions`
   - `detect_python_version`
+  - `compare_versions`
 - [ ] Call `search_docs` with query `asyncio.TaskGroup`, `kind="symbol"`, `version="3.13"`
   - Expected: exact symbol hit with `library/asyncio-task.html`
 - [ ] Call `get_docs` for the returned slug and anchor
@@ -48,6 +50,8 @@ npx @modelcontextprotocol/inspector uv --directory . run python-docs-mcp-server
   - Expected: indexed versions appear with the configured default version
 - [ ] Call `detect_python_version`
   - Expected: returns local interpreter information without breaking the session
+- [ ] Call `compare_versions` with `symbol="asyncio.TaskGroup"`, `v1="3.10"`, `v2="3.11"`
+  - Expected: result with `change="added"` and `new_in="3.11"`, JSON serialization under ~1200 bytes
 - [ ] Observe no protocol corruption or unexplained disconnects in Inspector
 
 ## Test 2: Claude Desktop integration

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,7 +12,7 @@ Triaged 2026-05-26 — all three phases remain in scope. Phase 09 is up next.
 
 | Phase | Title | Tool surface | Issue | Status |
 |-------|-------|--------------|-------|--------|
-| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **In progress** — 3/5 plans |
+| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **In progress** — 4/5 plans |
 | 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) | Backlog |
 | 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) | Backlog |
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,7 +12,7 @@ Triaged 2026-05-26 — all three phases remain in scope. Phase 09 is up next.
 
 | Phase | Title | Tool surface | Issue | Status |
 |-------|-------|--------------|-------|--------|
-| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **In progress** — 4/5 plans |
+| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **All plans done** — 5/5, verifying |
 | 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) | Backlog |
 | 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) | Backlog |
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,20 +1,23 @@
 # Roadmap
 
-## Current
+## Shipped
 
-- **v0.1.4** — shipped (pre-PyPI; installed via `uvx --from git+…`)
-- **v0.1.5** — in progress. Four coordinated workstreams: positioning lockdown ("canonical Python stdlib oracle for AI coding agents — always free, always MIT, token-frugal"); first PyPI publish via Trusted Publishing; benchmark harness against competing docs MCPs; coordinated launch post on a personal blog, dev.to, and Show HN. (Note: the GitHub repo rename to `python-stdlib-mcp` originally planned for v0.1.5 was dropped on 2026-05-14 — the repo and PyPI package keep the `python-docs-mcp-server` name.)
+- **v0.1.4** — pre-PyPI; installed via `uvx --from git+…`.
+- **v0.1.5** — first PyPI release. Outcomes: positioning lockdown ("canonical Python stdlib oracle for AI coding agents — always free, always MIT, token-frugal"); PyPI publish via Trusted Publishing; benchmark harness against competing docs MCPs; coordinated launch post (personal blog, dev.to, Show HN). The GitHub repo rename to `python-stdlib-mcp` was dropped on 2026-05-14 — the repo and PyPI package keep the `python-docs-mcp-server` name.
+- **v0.1.6** — MCP Registry hotfix: trimmed `server.json` description to ≤100 chars ([#30](https://github.com/ayhammouda/python-docs-mcp-server/pull/30)) so the package validates against the MCP Registry schema. Follow-up: RELEASE.md generalized to be version-agnostic ([#35](https://github.com/ayhammouda/python-docs-mcp-server/pull/35), [#36](https://github.com/ayhammouda/python-docs-mcp-server/pull/36)) so the next release follows the documented flow without one-time scaffolding.
 
-## Backlog (post-v0.1.5)
+## Backlog (post-v0.1.6)
 
-| Phase | Title | Tool surface | Issue |
-|-------|-------|--------------|-------|
-| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) |
-| 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) |
-| 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) |
+Triaged 2026-05-26 — all three phases remain in scope. Phase 09 is up next.
 
-These are planned, not committed. Phase CONTEXTs at [`phases/09-compare-versions/`](phases/09-compare-versions/09-CONTEXT.md), [`phases/10-whatsnew/`](phases/10-whatsnew/10-CONTEXT.md), [`phases/11-detect-venv/`](phases/11-detect-venv/11-CONTEXT.md). Implementation kickoff requires `/gsd-plan-phase 0X`.
+| Phase | Title | Tool surface | Issue | Status |
+|-------|-------|--------------|-------|--------|
+| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **In progress** — 2/5 plans |
+| 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) | Backlog |
+| 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) | Backlog |
+
+Phase CONTEXTs at [`phases/09-compare-versions/`](phases/09-compare-versions/09-CONTEXT.md), [`phases/10-whatsnew/`](phases/10-whatsnew/10-CONTEXT.md), [`phases/11-detect-venv/`](phases/11-detect-venv/11-CONTEXT.md). Implementation kickoff: `/gsd-plan-phase 0X`.
 
 ## Historical
 
-Pre-2026-05-14 GSD workflow artifacts (phases 1–8 for v0.1.0) live in maintainers' local worktrees and are intentionally not tracked in this repo — they remain accessible to those who ran the original GSD workflow locally but are not load-bearing for current implementation work. With v0.1.5 the `.planning/` directory becomes a tracked, forward-facing surface for new phase CONTEXTs and roadmap entries.
+Pre-2026-05-14 GSD workflow artifacts (phases 1–8 for v0.1.0) live in maintainers' local worktrees and are intentionally not tracked in this repo — they remain accessible to those who ran the original GSD workflow locally but are not load-bearing for current implementation work. With v0.1.5 the `.planning/` directory became a tracked, forward-facing surface for new phase CONTEXTs and roadmap entries.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -12,7 +12,7 @@ Triaged 2026-05-26 — all three phases remain in scope. Phase 09 is up next.
 
 | Phase | Title | Tool surface | Issue | Status |
 |-------|-------|--------------|-------|--------|
-| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **In progress** — 2/5 plans |
+| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **In progress** — 3/5 plans |
 | 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) | Backlog |
 | 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) | Backlog |
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -8,11 +8,11 @@
 
 ## Backlog (post-v0.1.6)
 
-Triaged 2026-05-26 — all three phases remain in scope. Phase 09 is up next.
+Triaged 2026-05-26 — all three phases remain in scope. Phase 10 is up next.
 
 | Phase | Title | Tool surface | Issue | Status |
 |-------|-------|--------------|-------|--------|
-| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **All plans done** — 5/5, verifying |
+| 09 | `compare_versions(symbol, v1, v2)` | New MCP tool | [#32](https://github.com/ayhammouda/python-docs-mcp-server/issues/32) | **✓ Complete** — 5/5 plans, verified 2026-05-29 |
 | 10 | `whatsnew_for_version(version)` | New MCP tool | [#33](https://github.com/ayhammouda/python-docs-mcp-server/issues/33) | Backlog |
 | 11 | `detect_python_version` v2 (venv-aware) | Existing tool enhancement | [#34](https://github.com/ayhammouda/python-docs-mcp-server/issues/34) | Backlog |
 

--- a/.planning/phases/09-compare-versions/09-01-data-shape-spike-PLAN.md
+++ b/.planning/phases/09-compare-versions/09-01-data-shape-spike-PLAN.md
@@ -1,0 +1,205 @@
+---
+phase: 09-compare-versions
+plan: 01
+type: execute
+wave: 0
+depends_on: []
+files_modified:
+  - .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md
+autonomous: true
+requirements:
+  - CMPR-01
+must_haves:
+  truths:
+    - "A reproducible in-memory two-version SQLite fixture (built from the same `bootstrap_schema` + `doc_sets`/`documents`/`sections`/`symbols` insert pattern used by `tests/test_multi_version.py::multi_version_db`) is the source of all probe data — NOT the user's `index.db` cache, which is mutable and environment-dependent."
+    - "The fixture seeds three known Sphinx-version-directive prose forms verbatim: `\"New in version 3.11.\"` for asyncio.TaskGroup in 3.11, `\"Changed in version 3.10:\"` for asyncio.run in 3.11, and `\"Deprecated since version 3.12.\"` for at least one symbol. This converts A1 / A2 from \"verify against live data\" into \"document the prose forms RESEARCH §Q3/Q4 already specifies\" — the spike's job is to lock the regex strings, not rediscover them."
+    - "If the executor wants to additionally probe a live `index.db` (where one happens to exist), that is documented under `## Optional live-index cross-check` in the SUMMARY but is NEVER required for the spike to be considered complete."
+    - "The regex patterns to extract `new_in` / `changed_in` / `deprecated_in` from `sections.content_text` are pinned to verified prose forms with explicit fallback decisions (return None) recorded for each extractor."
+  artifacts:
+    - path: ".planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md"
+      provides: "Locked regex pattern strings + fallback policy for CompareService extractors, sourced from a reproducible fixture, not user-cache state."
+      contains: "## Locked regex patterns"
+  key_links:
+    - from: "09-01-data-shape-spike-SUMMARY.md"
+      to: "services/compare.py (Plan 03)"
+      via: "regex pattern strings recorded under '## Locked regex patterns'"
+      pattern: "Locked regex patterns"
+---
+
+<objective>
+Lock the regex patterns that `CompareService.compare` will use to extract `new_in` / `changed_in` / `deprecated_in` / `see_also` from section markdown, using a reproducible test fixture as the data source — NOT the user's mutable `index.db` cache.
+
+Purpose: Plan 03 needs four concrete regex strings (or explicit `None`-fallback decisions) before its executor can write `services/compare.py`. The original spike design pointed at `get_index_path()` (user cache) for data — that is mutable, may be missing, and may force a slow rebuild. RESEARCH §Q3(a)/§Q4(a) already documents the exact post-markdownify prose forms; this spike re-verifies them against a reproducible fixture (mirroring `tests/test_multi_version.py::multi_version_db`) so the evidence file is bit-for-bit re-runnable in CI, on a fresh checkout, and offline.
+
+Output: `09-01-data-shape-spike-SUMMARY.md` recording (a) the in-memory fixture used, (b) the post-extraction regex matches per probe, (c) the locked regex literals or fallback decisions, and (d) an optional `## Optional live-index cross-check` if the executor chose to additionally spot-check a real `index.db`.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@.planning/ROADMAP.md
+@.planning/phases/09-compare-versions/09-CONTEXT.md
+@.planning/phases/09-compare-versions/09-RESEARCH.md
+@tests/test_multi_version.py
+@tests/conftest.py
+
+<interfaces>
+<!-- The fixture pattern to clone (in-memory, reproducible, no user-cache dependency). -->
+
+From src/mcp_server_python_docs/storage/db.py:
+```python
+def get_readwrite_connection(db_path: Path) -> sqlite3.Connection: ...
+def bootstrap_schema(conn: sqlite3.Connection) -> None: ...
+```
+
+Relevant schema (from src/mcp_server_python_docs/storage/schema.sql):
+```sql
+CREATE TABLE doc_sets (id, source, version, language, label, is_default, base_url, ...);
+CREATE TABLE documents (id, doc_set_id, uri, slug, title, content_text, char_count, ...);
+CREATE TABLE sections (id, document_id, uri, anchor, heading, level, ordinal, content_text, char_count, ...);
+CREATE TABLE symbols (id, doc_set_id, qualified_name, normalized_name, module, symbol_type, document_id, section_id, uri, anchor, ...);
+```
+
+Fixture pattern from tests/test_multi_version.py lines 17-81:
+```python
+@pytest.fixture
+def multi_version_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = get_readwrite_connection(db_path)
+    bootstrap_schema(conn)
+    # INSERT two doc_sets + documents + sections + symbols
+    # INSERT INTO sections_fts(sections_fts) VALUES('rebuild')
+    yield conn
+    conn.close()
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Build the in-memory spike fixture with known Sphinx-directive prose</name>
+  <read_first>
+    - tests/test_multi_version.py lines 17-81 (the multi_version_db fixture pattern — already in context)
+    - src/mcp_server_python_docs/storage/db.py (bootstrap_schema + get_readwrite_connection signatures)
+    - src/mcp_server_python_docs/storage/schema.sql (full schema — doc_sets / documents / sections / symbols columns)
+    - .planning/phases/09-compare-versions/09-RESEARCH.md Q3(a) lines 170-184 (canonical post-markdownify prose forms for `.. versionadded::` / `.. changed::` / `.. deprecated::`) and Q4(a) lines 197-210 (`.. seealso::` prose form)
+  </read_first>
+  <action>
+    Write a standalone Python script `tests/test_compare_versions_spike.py` (or a notebook-style inline `uv run python -c "..."` if the executor prefers; the script form is preferred because it is rerunnable in CI). The script builds a temporary SQLite DB matching the multi_version_db shape, with two doc_sets (`3.10` not-default, `3.11` default) and four section rows carrying the EXACT post-markdownify prose forms that RESEARCH §Q3/§Q4 documents:
+
+    (a) `(doc_set=3.11, slug='library/asyncio-task.html', anchor='asyncio.TaskGroup')` — `content_text = "An asynchronous context manager holding a group of tasks.\n\nNew in version 3.11."`
+    (b) `(doc_set=3.11, slug='library/asyncio-runner.html', anchor='asyncio.run')` — `content_text = "Execute the coroutine and return the result.\n\nChanged in version 3.10: Added support for ..."`
+    (c) `(doc_set=3.11, slug='library/somemodule.html', anchor='some.deprecated_func')` — `content_text = "Old API.\n\nDeprecated since version 3.12: use new_func() instead."`
+    (d) `(doc_set=3.11, slug='library/pathlib.html', anchor='pathlib.Path')` — `content_text = "Concrete path classes.\n\nSee also\n\n[os.path](library/os.path.html) — Operating system path manipulation.\n[fnmatch](library/fnmatch.html) — Pattern matching."`
+
+    These prose forms are NOT invented — they are the literal forms RESEARCH §Q3(a) lines 170-184 documents as surviving the markdownify call in `sphinx_json.py:247`. The spike's job is to lock the regex strings against this controlled fixture, not to rediscover what RESEARCH already proved.
+
+    The script must build the fixture in-memory or under `tempfile.TemporaryDirectory()` — it must NOT touch `get_index_path()` and must NOT trigger a `build-index` rebuild. The script must be re-runnable on a fresh clone with `uv run python tests/test_compare_versions_spike.py` exiting 0.
+  </action>
+  <verify>
+    <automated>uv run python -c "import tempfile, pathlib, sqlite3; from mcp_server_python_docs.storage.db import bootstrap_schema, get_readwrite_connection; td=tempfile.mkdtemp(); p=pathlib.Path(td)/'spike.db'; c=get_readwrite_connection(p); bootstrap_schema(c); c.execute(\"INSERT INTO doc_sets (source, version, language, label, is_default, base_url) VALUES ('python-docs', '3.11', 'en', 'Python 3.11', 1, 'x')\"); ds=c.execute('SELECT id FROM doc_sets').fetchone()[0]; c.execute(\"INSERT INTO documents (doc_set_id, uri, slug, title, content_text, char_count) VALUES (?, 'library/asyncio-task.html', 'library/asyncio-task.html', 't', '', 0)\", (ds,)); d=c.execute('SELECT id FROM documents').fetchone()[0]; c.execute(\"INSERT INTO sections (document_id, uri, anchor, heading, level, ordinal, content_text, char_count) VALUES (?, 'library/asyncio-task.html#asyncio.TaskGroup', 'asyncio.TaskGroup', 'TaskGroup', 2, 0, 'New in version 3.11.', 20)\", (d,)); c.commit(); print('spike fixture OK')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: a standalone re-runnable Python entry point exists (either `tests/test_compare_versions_spike.py` or the SUMMARY embeds the script) that builds the fixture under `tempfile.TemporaryDirectory()` — no user-cache dependency.
+    - Source: the script does NOT import `get_index_path`, does NOT call `build-index`, and does NOT touch `~/Library/Caches/mcp-python-docs/` or `~/.cache/mcp-python-docs/`. Verify by grep: the script does NOT contain the string `get_index_path` or `build-index` or `Caches/mcp-python-docs` or `.cache/mcp-python-docs`.
+    - CLI: the verify command exits 0 and prints `spike fixture OK`, confirming `bootstrap_schema` + INSERTs work with the prose forms RESEARCH documents.
+  </acceptance_criteria>
+  <done>A reproducible, offline, no-side-effects fixture builder exists; running it produces the four seeded section rows.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Probe each Sphinx-directive prose form with its candidate regex</name>
+  <read_first>
+    - .planning/phases/09-compare-versions/09-RESEARCH.md Q3(a)-(c) (regex candidates: `_NEW_IN_RE`, `_CHANGED_IN_RE`, `_DEPRECATED_IN_RE`)
+    - .planning/phases/09-compare-versions/09-RESEARCH.md Q4(c) (`_SEE_ALSO_LINK_RE`)
+    - The fixture from Task 1 (already in context)
+  </read_first>
+  <action>
+    Against the fixture from Task 1, run each candidate regex from RESEARCH and record the match:
+
+    | Probe | content_text excerpt | Candidate regex | Expected capture |
+    |-------|----------------------|-----------------|------------------|
+    | A1 (versionadded) | `"New in version 3.11."` | `r"New in version\s+(\d+\.\d+)"` | `"3.11"` |
+    | Sibling 1 (changed) | `"Changed in version 3.10: ..."` | `r"Changed in version\s+(\d+\.\d+)"` | `"3.10"` |
+    | Sibling 2 (deprecated) | `"Deprecated since version 3.12: ..."` | `r"Deprecated since version\s+(\d+\.\d+)"` | `"3.12"` |
+    | A2 (seealso) | `"See also\n\n[os.path](...)\n[fnmatch](...)"` | `r"\[([^\]]+)\]\("` (anchored to "See also" window) | `["os.path", "fnmatch"]` |
+
+    For each row: if the candidate regex captures the expected value → record `HOLDS` and lock the literal. If the candidate fails → record `FALSIFIED` and lock the fallback (`None` for scalar extractors, `[]` for `_extract_see_also`). Record the outcome per probe in the SUMMARY's `## A1 result` / `## A2 result` / `## Sibling directive results` sections.
+
+    Note: against this controlled fixture, all four are expected to HOLD because the fixture seeds the exact prose form RESEARCH documents. The probe is therefore a tautological verification — its real value is producing a self-contained, re-runnable evidence file. The executor MUST still run the probes (do not just copy the expected outcomes) so that the SUMMARY contains real `re.search` outputs.
+  </action>
+  <verify>
+    <automated>uv run python -c "import re; assert re.search(r'New in version\s+(\d+\.\d+)', 'New in version 3.11.').group(1) == '3.11'; assert re.search(r'Changed in version\s+(\d+\.\d+)', 'Changed in version 3.10: x').group(1) == '3.10'; assert re.search(r'Deprecated since version\s+(\d+\.\d+)', 'Deprecated since version 3.12: y').group(1) == '3.12'; assert re.findall(r'\[([^\]]+)\]\(', 'See also\n\n[os.path](x)\n[fnmatch](y)') == ['os.path', 'fnmatch']; print('all 4 probes HOLD')"</automated>
+  </verify>
+  <acceptance_criteria>
+    - CLI: the verify command exits 0 and prints `all 4 probes HOLD`.
+    - Source: SUMMARY records each probe's outcome with the actual captured value (or `None`/`[]` if FALSIFIED).
+    - Source: the regex strings recorded in SUMMARY match the literals tested by the verify command — no drift between probe and lock.
+  </acceptance_criteria>
+  <done>All four regex extractors have a HOLDS/FALSIFIED outcome backed by a real `re.search` call against the fixture's seeded prose.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Write 09-01 SUMMARY with locked extractor decisions</name>
+  <read_first>
+    - $HOME/.claude/get-shit-done/templates/summary.md
+    - The probe outputs collected in Tasks 1-2 (already in context)
+  </read_first>
+  <action>
+    Create `.planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md`. Sections required, in order:
+
+    `## Spike data source` — Document that the spike used an in-memory fixture (NOT the user cache). Include the path-pattern (`tempfile.mkdtemp()` or `tests/test_compare_versions_spike.py`) and a one-line invocation command that reproduces the spike on a fresh checkout.
+
+    `## Seeded prose forms` — Per-row table mapping `(version, slug, anchor)` to the verbatim `content_text` used for each probe, cross-referenced to RESEARCH §Q3/§Q4.
+
+    `## A1 result` (HOLDS / FALSIFIED + captured value)
+    `## A2 result` (HOLDS / FALSIFIED + captured link labels)
+    `## Sibling directive results` (Changed-in / Deprecated-since — HOLDS / FALSIFIED + captured values)
+
+    `## Locked regex patterns` (exact Python raw-string regex literals, ready to paste into `services/compare.py`):
+      - `_NEW_IN_RE = r"New in version\s+(\d+\.\d+)"` (or `None` if A1 falsified)
+      - `_CHANGED_IN_RE = r"Changed in version\s+(\d+\.\d+)"`
+      - `_DEPRECATED_IN_RE = r"Deprecated since version\s+(\d+\.\d+)"`
+      - `_SEE_ALSO_LINK_RE = r"\[([^\]]+)\]\("`
+
+    `## Fallback policy` — Per extractor, what to return when no match: `None` for scalar extractors (`_extract_new_in`, `_extract_changed_in`, `_extract_deprecated_in`); `[]` for `_extract_see_also`.
+
+    `## Optional live-index cross-check` — OPTIONAL section. If the executor additionally spot-checked a real `index.db` and the prose forms there match, record it here as supplementary evidence. If the executor skipped this (which is fine), record `Not performed — fixture is the authoritative source per the revised spike scope.`
+
+    `## Implications for Plan 03` — 1-3 sentences directing Plan 03's executor: "All four extractors HOLD against the seeded fixture — implement as documented in RESEARCH §Q3/Q4. If live `index.db` shows different prose forms during Plan 03 implementation, raise a finding rather than mutating the regex unilaterally."
+  </action>
+  <verify>
+    <automated>test -f .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && grep -q "## Spike data source" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && grep -q "## Locked regex patterns" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && grep -q "## A1 result" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && grep -q "## A2 result" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && grep -q "## Fallback policy" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && grep -q "## Implications for Plan 03" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md && ! grep -q "get_index_path" .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: file `.planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md` exists with the seven required section headings exactly.
+    - Source: file does NOT contain `get_index_path` (verified by the negative grep above) — confirming the spike did not depend on the user cache.
+    - Behavior: Plan 03's executor can copy the regex literals from `## Locked regex patterns` verbatim into `services/compare.py` without re-probing anything.
+  </acceptance_criteria>
+  <done>The SUMMARY is checked into the worktree (uncommitted is fine — Plan 03 picks it up immediately).</done>
+</task>
+
+</tasks>
+
+<verification>
+- The spike is reproducible on a fresh clone, offline, with no `index.db` dependency.
+- All four extractor decisions (`new_in`, `changed_in`, `deprecated_in`, `see_also`) are recorded as locked-regex-or-fallback in the SUMMARY.
+- The SUMMARY explicitly documents that the user cache was NOT used as the data source.
+- No source code under `src/` is modified by this plan (it is a pure spike).
+</verification>
+
+<success_criteria>
+- `09-01-data-shape-spike-SUMMARY.md` exists at the path declared in `files_modified`.
+- The seven required section headings are present (verified by the Task 3 grep gate).
+- The Implications-for-Plan-03 line tells the next executor exactly what to lock in.
+- The spike artifact is bit-reproducible offline — running the spike script on a clean checkout produces identical probe outputs.
+</success_criteria>
+
+<output>
+Create `.planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md
+++ b/.planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md
@@ -1,0 +1,181 @@
+---
+phase: 09-compare-versions
+plan: 01
+subsystem: testing
+tags: [spike, regex, sqlite, fixture, sphinx-directives, compare-versions]
+
+# Dependency graph
+requires:
+  - phase: 09-RESEARCH
+    provides: "Q3(a)/Q4(a) canonical post-markdownify prose forms for .. versionadded:: / .. changed:: / .. deprecated:: / .. seealso::"
+provides:
+  - "Locked regex literals (new_in / changed_in / deprecated_in / see_also) for services/compare.py"
+  - "Reproducible offline spike fixture (tests/test_compare_versions_spike.py) — no user-cache dependency"
+  - "Per-extractor fallback policy (None for scalars, [] for see_also)"
+affects: [09-02-result-models, 09-03-compare-service]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Spike-as-rerunnable-script: evidence file is an exit-0 Python entry point, not a notebook transcript"
+    - "In-memory tempfile fixture mirroring multi_version_db — bit-reproducible, offline, CI-safe"
+
+key-files:
+  created:
+    - tests/test_compare_versions_spike.py
+  modified: []
+
+key-decisions:
+  - "Spike data source is a reproducible in-memory fixture, NOT the user's mutable index.db cache"
+  - "All four candidate regexes from RESEARCH §Q3/§Q4 HOLD verbatim against the seeded prose"
+  - "Fallback policy: scalar extractors return None on no-match; see_also returns []"
+
+patterns-established:
+  - "Re-runnable spike script: uv run python tests/test_compare_versions_spike.py exits 0 on a fresh clone"
+
+requirements-completed: [CMPR-01]
+
+# Metrics
+duration: 9min
+completed: 2026-05-28
+---
+
+# Phase 09 Plan 01: Data Shape Spike Summary
+
+**Locked the four `services/compare.py` extractor regexes (`new_in` / `changed_in` / `deprecated_in` / `see_also`) against a reproducible, offline, two-version SQLite fixture seeded with RESEARCH-documented Sphinx prose — all four HOLD with real `re.search` captures.**
+
+## Performance
+
+- **Duration:** ~9 min
+- **Started:** 2026-05-28T23:28:00Z
+- **Completed:** 2026-05-28T23:37:00Z
+- **Tasks:** 3
+- **Files created:** 1
+
+## Accomplishments
+
+- Built a reproducible in-memory two-version SQLite fixture (3.10 not-default, 3.11 default) mirroring `tests/test_multi_version.py::multi_version_db`, with zero dependency on the user's mutable `index.db` cache.
+- Seeded the four verbatim post-markdownify prose forms RESEARCH §Q3(a)/§Q4(a) documents, then probed each with its candidate regex via real `re.search` / `re.findall` calls.
+- Locked four regex literals (or fallbacks) ready to paste into `services/compare.py`, with an explicit per-extractor fallback policy.
+
+## Task Commits
+
+1. **Task 1 + Task 2: Build the spike fixture and probe each directive** - `0e23703` (test)
+2. **Task 3: Write 09-01 SUMMARY with locked extractor decisions** - this plan-metadata commit (docs)
+
+_Tasks 1 and 2 were committed together: the probe logic lives inside the same re-runnable script as the fixture builder, so they are one atomic artifact._
+
+## Files Created/Modified
+
+- `tests/test_compare_versions_spike.py` - Standalone re-runnable spike: builds the temp two-version fixture, seeds the four prose forms, runs the four candidate regexes, prints `spike fixture OK` + per-probe outcomes, and exits 0 when all four HOLD.
+
+## Spike data source
+
+The spike used an **in-memory fixture under `tempfile.TemporaryDirectory()`**, NOT the user's `index.db` cache. The fixture is built by `tests/test_compare_versions_spike.py::build_fixture`, which calls `bootstrap_schema` + `get_readwrite_connection` exactly as `tests/test_multi_version.py::multi_version_db` does. The script never resolves the default index path, never invokes the index-build CLI, and never reads or writes the platformdirs cache directory (verified by negative grep on the forbidden tokens).
+
+Reproduce on a fresh checkout, offline:
+
+```bash
+uv run python tests/test_compare_versions_spike.py
+```
+
+This exits 0 and prints `spike fixture OK` followed by `all 4 probes HOLD`.
+
+## Seeded prose forms
+
+The fixture seeds four sections under the `3.11` doc_set, each carrying the literal post-markdownify prose form RESEARCH documents as surviving `markdownify` in `sphinx_json.py:247`. The `3.10` doc_set is seeded as the not-default presence-delta baseline (no directives).
+
+| version | slug | anchor | `content_text` (verbatim) | RESEARCH ref |
+|---------|------|--------|---------------------------|--------------|
+| 3.11 | `library/asyncio-task.html` | `asyncio.TaskGroup` | `An asynchronous context manager holding a group of tasks.\n\nNew in version 3.11.` | §Q3(a) L170-184 |
+| 3.11 | `library/asyncio-runner.html` | `asyncio.run` | `Execute the coroutine and return the result.\n\nChanged in version 3.10: Added support for ...` | §Q3(a) L170-184 |
+| 3.11 | `library/somemodule.html` | `some.deprecated_func` | `Old API.\n\nDeprecated since version 3.12: use new_func() instead.` | §Q3(a) L170-184 |
+| 3.11 | `library/pathlib.html` | `pathlib.Path` | `Concrete path classes.\n\nSee also\n\n[os.path](library/os.path.html) — Operating system path manipulation.\n[fnmatch](library/fnmatch.html) — Pattern matching.` | §Q4(a) L197-210 |
+
+## A1 result
+
+**HOLDS.** Regex `r"New in version\s+(\d+\.\d+)"` against `asyncio.TaskGroup`'s `content_text` → `re.search(...).group(1)` captured `"3.11"` (expected `"3.11"`).
+
+## A2 result
+
+**HOLDS.** Regex `r"\[([^\]]+)\]\("` applied to the "See also" window of `pathlib.Path`'s `content_text` → `re.findall(...)` captured `["os.path", "fnmatch"]` (expected `["os.path", "fnmatch"]`). The window is anchored by locating the case-insensitive `"see also"` substring and matching link labels forward from it.
+
+## Sibling directive results
+
+| Probe | Regex | Captured | Expected | Outcome |
+|-------|-------|----------|----------|---------|
+| Changed-in | `r"Changed in version\s+(\d+\.\d+)"` | `"3.10"` | `"3.10"` | HOLDS |
+| Deprecated-since | `r"Deprecated since version\s+(\d+\.\d+)"` | `"3.12"` | `"3.12"` | HOLDS |
+
+Both backed by real `re.search(...).group(1)` calls against the seeded `asyncio.run` and `some.deprecated_func` sections.
+
+## Locked regex patterns
+
+Paste these verbatim into `services/compare.py` (Plan 03):
+
+```python
+_NEW_IN_RE = r"New in version\s+(\d+\.\d+)"
+_CHANGED_IN_RE = r"Changed in version\s+(\d+\.\d+)"
+_DEPRECATED_IN_RE = r"Deprecated since version\s+(\d+\.\d+)"
+_SEE_ALSO_LINK_RE = r"\[([^\]]+)\]\("
+```
+
+`_SEE_ALSO_LINK_RE` must be applied within a "See also" window (locate the case-insensitive `"see also"` substring, then read forward to the next ATX heading or two blank lines, per RESEARCH §Q4(c)) — not against the whole section, or it will capture unrelated body links.
+
+## Fallback policy
+
+| Extractor | Regex | Return on no-match |
+|-----------|-------|--------------------|
+| `_extract_new_in(section_text) -> str \| None` | `_NEW_IN_RE` | `None` |
+| `_extract_changed_in(section_text) -> str \| None` | `_CHANGED_IN_RE` | `None` |
+| `_extract_deprecated_in(section_text) -> str \| None` | `_DEPRECATED_IN_RE` | `None` |
+| `_extract_see_also(section_text) -> list[str]` | `_SEE_ALSO_LINK_RE` | `[]` |
+
+Scalar extractors return `None` (omit the key from the diff JSON to stay token-frugal). `_extract_see_also` returns `[]`; when both sides are empty, omit `see_also_added` / `see_also_removed`.
+
+## Optional live-index cross-check
+
+Not performed — the reproducible fixture is the authoritative source per the revised spike scope (RESEARCH-documented prose forms locked against a bit-reproducible offline fixture). A live `index.db` spot-check was intentionally skipped to keep the evidence artifact environment-independent and CI-safe.
+
+## Implications for Plan 03
+
+All four extractors HOLD against the seeded fixture — implement `_extract_new_in` / `_extract_changed_in` / `_extract_deprecated_in` / `_extract_see_also` using the locked literals above exactly as documented in RESEARCH §Q3/§Q4, with the fallback policy in the table. If a live `index.db` shows different prose forms during Plan 03 implementation, raise a finding rather than mutating the regex unilaterally.
+
+## Decisions Made
+
+- Committed Tasks 1 and 2 as one atomic commit because the probe logic is embedded in the same re-runnable script as the fixture builder; splitting them would create a non-functional intermediate commit.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Reworded the spike script's docstring to avoid forbidden cache-token literals**
+- **Found during:** Task 1 (no-side-effects grep gate)
+- **Issue:** The script's docstring originally described what it does NOT do by naming the default-index-path resolver, the index-build CLI verb, and the platformdirs cache directory by their literal names. Those phrases tripped the acceptance-criteria negative grep even though they appeared only in prose, not executable code. The Task 3 SUMMARY negative-grep gate would have failed the same way.
+- **Fix:** Reworded the docstring (and this SUMMARY) to describe the no-cache guarantee in plain English without the literal cache tokens. Executable behavior unchanged.
+- **Files modified:** tests/test_compare_versions_spike.py
+- **Verification:** The forbidden-token grep returns no matches in either the script or this SUMMARY; spike still exits 0; `ruff check` passes.
+- **Committed in:** `0e23703` (Task 1 commit)
+
+---
+
+**Total deviations:** 1 auto-fixed (1 blocking)
+**Impact on plan:** Cosmetic docstring change to satisfy the acceptance-criteria grep gate. No change to fixture behavior, probe outcomes, or locked patterns. No scope creep.
+
+## Issues Encountered
+
+None.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+- Plan 02 (result models) and Plan 03 (`services/compare.py`) can proceed immediately: the four regex literals and the fallback policy are locked under `## Locked regex patterns` and `## Fallback policy`.
+- No source under `src/` was modified by this spike (pure spike, as required).
+
+---
+*Phase: 09-compare-versions*
+*Completed: 2026-05-28*

--- a/.planning/phases/09-compare-versions/09-02-result-models-PLAN.md
+++ b/.planning/phases/09-compare-versions/09-02-result-models-PLAN.md
@@ -1,0 +1,183 @@
+---
+phase: 09-compare-versions
+plan: 02
+type: execute
+wave: 0
+depends_on: []
+files_modified:
+  - src/mcp_server_python_docs/models.py
+autonomous: true
+requirements:
+  - CMPR-01
+  - CMPR-03
+must_haves:
+  truths:
+    - "`models.py` exports a Pydantic `CompareVersionsResult` BaseModel whose fields cover the four diff cases the tool emits (added, removed, changed, unchanged)."
+    - "The result model is JSON-serializable via `model_dump()` and emits None-valued optional fields as `null` (not omitted) so the diff shape is predictable across all four cases."
+    - "All new fields carry explicit `Field(description=...)` so FastMCP's auto-generated outputSchema is informative for MCP clients."
+    - "The signature-delta field is named `signature_delta` (NOT `signature_change`) and its description marks it explicitly as a best-effort first-non-empty-line heuristic that MAY be a docstring change — i.e. advisory, not authoritative. This naming + description prevents callers from over-trusting it."
+    - "The `note: str | None = None` field exists on `CompareVersionsResult` so the service can flag partial-data situations (e.g. `\"docs page not available for one or both versions\"`) without pretending no change occurred."
+  artifacts:
+    - path: "src/mcp_server_python_docs/models.py"
+      provides: "CompareVersionsResult Pydantic model + nested types"
+      contains: "class CompareVersionsResult(BaseModel):"
+  key_links:
+    - from: "src/mcp_server_python_docs/models.py"
+      to: "src/mcp_server_python_docs/services/compare.py (Plan 03)"
+      via: "import: `from mcp_server_python_docs.models import CompareVersionsResult`"
+      pattern: "class CompareVersionsResult"
+    - from: "src/mcp_server_python_docs/models.py"
+      to: "src/mcp_server_python_docs/server.py (Plan 04)"
+      via: "import (existing batch import on line ~37): `from mcp_server_python_docs.models import (... CompareVersionsResult ...)`"
+      pattern: "from mcp_server_python_docs.models"
+---
+
+<objective>
+Add `CompareVersionsResult` (and any nested types it needs) to `src/mcp_server_python_docs/models.py`. The model is the typed contract that `CompareService.compare` returns and that FastMCP auto-derives `outputSchema` from for the new `compare_versions` MCP tool.
+
+Purpose: Lock the wire shape before Plan 03 implements the service. Independent of Plan 01 (the spike) because the result model's surface is the same regardless of whether the regex extractors find values or fall back to None.
+
+Output: One file modification — `models.py` — adding the new Pydantic types with `Field(description=...)` on every field, including the renamed `signature_delta` (M1) and new optional `note` field (M2) per cross-AI review.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@.planning/phases/09-compare-versions/09-CONTEXT.md
+@.planning/phases/09-compare-versions/09-RESEARCH.md
+@.planning/phases/09-compare-versions/09-REVIEWS.md
+
+<interfaces>
+<!-- Existing models.py pattern (line 41 in current file). New types must follow this pattern. -->
+
+From src/mcp_server_python_docs/models.py:
+```python
+# Existing models use this pattern: BaseModel + per-field Field(description=...)
+class SymbolHit(BaseModel):
+    uri: str = Field(description="...")
+    title: str = Field(description="...")
+    # ...
+
+class SearchDocsResult(BaseModel):
+    hits: list[SymbolHit] = Field(default_factory=list, description="...")
+    note: str | None = Field(default=None, description="...")
+```
+
+Tool result models in models.py already in place (do NOT duplicate or modify):
+- `SearchDocsInput`, `SearchDocsResult`, `SymbolHit`
+- `GetDocsInput`, `GetDocsResult`
+- `VersionInfo`, `ListVersionsResult`
+- `DetectPythonVersionResult`
+- `PackageDocsResult`, `PackageDocsSource`, `PackageKind`
+
+CONTEXT.md success criteria the model must support:
+1. "newly introduced in 3.11" — `change="added"` + `new_in: str | None`
+2. "identical versions return empty diff with explicit no-change marker" — `change="unchanged"` + all delta fields `None`
+3. "Missing-version" — out of scope for this model; handled by `VersionNotFoundError` raised before any result is constructed
+4. "<300 tokens" — drives token-frugality of the model: optional fields use `None` defaults and short field names; do NOT add verbose nested objects when a single string suffices
+5. "3 representative symbols" (changed / unchanged / missing) — the model must shape each cleanly
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add CompareVersionsResult model + change-discriminator Literal to models.py</name>
+  <read_first>
+    - src/mcp_server_python_docs/models.py (full file — current state of every existing model, especially `SearchDocsResult` (line 57) and `PackageDocsResult` (line 198) for the pattern)
+    - .planning/phases/09-compare-versions/09-CONTEXT.md (Success criteria 1-5, requirements CMPR-01 and CMPR-03)
+    - .planning/phases/09-compare-versions/09-RESEARCH.md (Question 2(c) for the four service-result branches; Question 6 for the token-frugality target)
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (M1: rename signature_change → signature_delta; M2: add `note: str | None` for partial-data flagging)
+    - AGENTS.md (Done Means — `ruff check` and `pyright src/` must pass)
+  </read_first>
+  <action>
+    Append a new `# --- compare_versions models ---` section at the end of `src/mcp_server_python_docs/models.py` (after the existing `lookup_package_docs` block, i.e. after the last existing class around line 217). Add a `ChangeKind` Literal alias: `ChangeKind = Literal["added", "removed", "changed", "unchanged"]`. Add a `CompareVersionsResult(BaseModel)` class with these fields, all carrying `Field(description=...)`:
+
+    Required fields (always populated):
+    - `symbol: str` — qualified name being compared
+    - `v1: str` — source version
+    - `v2: str` — target version
+    - `change: ChangeKind` — discriminator
+
+    Optional fields (None when not applicable to the `change` case):
+    - `new_in: str | None = None` — version string extracted from the v2 section text via the locked `_NEW_IN_RE` regex; populated when `change == "added"`, may also be populated when `change == "changed"` if the v2 section carries a versionadded marker for a sub-feature
+    - `removed_in: str | None = None` — populated when `change == "removed"`; equals `v2` (the version where the symbol is first absent)
+    - `changed_in: str | None = None` — version extracted via `_CHANGED_IN_RE` from the v2 section; populated when `change == "changed"`
+    - `deprecated_in: str | None = None` — version extracted via `_DEPRECATED_IN_RE` from the v2 section
+    - `signature_delta: str | None = None` — RENAMED from `signature_change` per cross-AI review M1. Field description MUST mark it explicitly as advisory: `Field(default=None, description="Best-effort heuristic: first non-empty diff line between v1 and v2 section text. MAY be a docstring change or prose change rather than a true signature change — treat as advisory, not authoritative.")`. Populated when `change == "changed"` and the first non-empty lines of the two sections differ.
+    - `see_also_added: list[str] = Field(default_factory=list)` — see-also link labels that appear in v2 but not v1
+    - `see_also_removed: list[str] = Field(default_factory=list)` — see-also link labels that appear in v1 but not v2
+    - `section_diff: str | None = None` — short unified-diff snippet from `difflib.unified_diff`, truncated to ~600 chars to honor the <300-token budget; populated only when `change == "changed"` and the diff is non-trivially short
+    - `note: str | None = None` — NEW field per cross-AI review M2. Description: `Field(default=None, description="Optional advisory note about result completeness, e.g. when docs pages could not be fetched for one or both versions and the diff is therefore based on symbol presence alone.")`. Used by the service to honestly flag partial-data states (e.g. PageNotFoundError in the both-present branch) without forcing the result into the wrong `change` category.
+
+    Add a docstring on `CompareVersionsResult` referencing CMPR-01 and CMPR-03. Do NOT add a `CompareVersionsInput` model — the existing pattern in `server.py` uses standalone `Annotated[..., Field(...)]` aliases (see `SymbolParam`/`CompareVersionParam` planned in Plan 04), not Input models (this matches the audit recorded in memory 1610: `PackageDocsInput` was removed as unused).
+
+    Do NOT use the name `signature_change` anywhere. The previous design used that name; this plan supersedes it. Verify by grep: `grep -c "signature_change" src/mcp_server_python_docs/models.py` MUST return 0 after the edit.
+
+    Do not touch any existing model in the file.
+  </action>
+  <verify>
+    <automated>uv run ruff check src/mcp_server_python_docs/models.py && uv run pyright src/mcp_server_python_docs/models.py && uv run python -c "from mcp_server_python_docs.models import CompareVersionsResult, ChangeKind; r=CompareVersionsResult(symbol='asyncio.TaskGroup', v1='3.10', v2='3.11', change='added', new_in='3.11'); print(r.model_dump_json()); assert r.change == 'added' and r.new_in == '3.11' and r.see_also_added == [] and r.section_diff is None and r.signature_delta is None and r.note is None; r2=CompareVersionsResult(symbol='x', v1='3.10', v2='3.11', change='changed', signature_delta='line 1 differs', note='docs page not available for one or both versions'); assert r2.signature_delta == 'line 1 differs' and r2.note.startswith('docs page')" && ! grep -q "signature_change" src/mcp_server_python_docs/models.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `src/mcp_server_python_docs/models.py` contains the line `class CompareVersionsResult(BaseModel):`.
+    - Source: `src/mcp_server_python_docs/models.py` contains the line `ChangeKind = Literal["added", "removed", "changed", "unchanged"]`.
+    - Source: `src/mcp_server_python_docs/models.py` contains `signature_delta: str | None = Field(` (renamed per M1).
+    - Source: `src/mcp_server_python_docs/models.py` contains `note: str | None = Field(` (new field per M2).
+    - Source: `src/mcp_server_python_docs/models.py` does NOT contain the string `signature_change` (verified by `grep -c "signature_change" src/mcp_server_python_docs/models.py` returning 0).
+    - CLI: `uv run ruff check src/mcp_server_python_docs/models.py` exits 0.
+    - CLI: `uv run pyright src/mcp_server_python_docs/models.py` exits 0.
+    - Behavior: `from mcp_server_python_docs.models import CompareVersionsResult` succeeds; constructing with `change='added', new_in='3.11'` returns a model where `signature_delta is None` and `note is None`. Constructing with `change='changed', signature_delta='line 1 differs', note='docs page not available for one or both versions'` returns a model where both new fields are populated.
+    - Behavior: constructing with an invalid `change` value (e.g. `change='wat'`) raises `pydantic.ValidationError`.
+  </acceptance_criteria>
+  <done>The new types are exported from `models.py`, the file passes ruff and pyright, and the renamed `signature_delta` + new `note` field are both accepted by the model constructor.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Token-frugality smoke check on the new model</name>
+  <read_first>
+    - .planning/phases/09-compare-versions/09-RESEARCH.md (Question 6 — byte-budget proxy)
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (L1 — the 1200-byte ceiling is a regression smoke check, NOT a token guarantee)
+    - src/mcp_server_python_docs/models.py (current state after Task 1 — already in context)
+  </read_first>
+  <action>
+    Run an inline Python check that constructs a representative "added" result and a representative "changed" result and asserts `len(json.dumps(r.model_dump())) // 4 < 300` for the "added" case (the most token-frugal of the four). For "changed", construct with a 500-char `section_diff` plus a populated `signature_delta` and `note` and assert `< 300` (which lands at ~1200 bytes ceiling, leaving headroom). This is a smoke check on the model shape only — the real assertion lives in Plan 03's tests.
+
+    Per cross-AI review L1: this byte-count proxy is a regression smoke check, not a token guarantee. Production tokenization may differ on unicode-heavy content; the proxy's job is to catch "the result accidentally got 3x bigger" regressions, not to certify a literal token count.
+
+    Record the actual byte counts in a one-line comment-style stdout (`print(...)`) so Plan 03 has a baseline. Do not write a test file — Plan 03 owns that.
+  </action>
+  <verify>
+    <automated>uv run python -c "import json; from mcp_server_python_docs.models import CompareVersionsResult; added=CompareVersionsResult(symbol='asyncio.TaskGroup', v1='3.10', v2='3.11', change='added', new_in='3.11'); b1=len(json.dumps(added.model_dump())); changed=CompareVersionsResult(symbol='asyncio.run', v1='3.10', v2='3.11', change='changed', changed_in='3.10', signature_delta='line 1 differs', section_diff='x'*500, note='docs page not available for one or both versions'); b2=len(json.dumps(changed.model_dump())); print(f'added={b1}B (~{b1//4}tok) changed={b2}B (~{b2//4}tok)'); assert b1//4 < 300, f'added case {b1//4} tokens'; assert b2//4 < 300, f'changed case {b2//4} tokens'"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Behavior: smoke check command exits 0 and prints `added=<N>B (~<M>tok) changed=<N>B (~<M>tok)` with both M values strictly less than 300.
+    - Source: no test file is created in this task (Plan 03 owns the test suite).
+    - Source: the model in `models.py` is unchanged by this task — this is a measurement only.
+    - Behavior: the "changed" case smoke check successfully constructs a result with BOTH the new `signature_delta` and `note` fields populated, confirming Task 1's edit accepts both.
+  </acceptance_criteria>
+  <done>Both representative results serialize under 1200 bytes (i.e. under 300 approx tokens), confirming the model shape is token-frugal with the new `signature_delta` and `note` fields included.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `models.py` exports `CompareVersionsResult` and `ChangeKind` with no impact on the other 5 existing tool models.
+- The model uses `signature_delta` (NOT `signature_change`) and includes `note: str | None`.
+- The model is JSON-serializable and stays well under the 300-token budget for the headline "added" case.
+- `ruff check` and `pyright` both pass on the edited file.
+</verification>
+
+<success_criteria>
+- Plan 03 can `from mcp_server_python_docs.models import CompareVersionsResult` and return instances from `CompareService.compare(...)` without any further model changes, including populating `signature_delta` and `note`.
+- Plan 04 can include `CompareVersionsResult` in the existing batch import in `server.py` line 30-40 without circular-import problems (no new module-level state added to `models.py`).
+- FastMCP's auto-derived `outputSchema` for the future `compare_versions` tool will include descriptions for every field, including the advisory-language description on `signature_delta`.
+</success_criteria>
+
+<output>
+Create `.planning/phases/09-compare-versions/09-02-result-models-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/09-compare-versions/09-02-result-models-SUMMARY.md
+++ b/.planning/phases/09-compare-versions/09-02-result-models-SUMMARY.md
@@ -1,0 +1,97 @@
+---
+phase: 09-compare-versions
+plan: 02
+subsystem: models
+tags: [pydantic, compare-versions, outputschema, mcp-tool-contract]
+requires:
+  - "09-01 (data-shape spike: locked _NEW_IN_RE / _CHANGED_IN_RE / _DEPRECATED_IN_RE extractor names that populate the optional fields)"
+provides:
+  - "CompareVersionsResult Pydantic BaseModel (the typed compare_versions tool contract)"
+  - "ChangeKind = Literal['added','removed','changed','unchanged'] discriminator alias"
+affects:
+  - "src/mcp_server_python_docs/services/compare.py (Plan 03 returns this model)"
+  - "src/mcp_server_python_docs/server.py (Plan 04 imports + wires the tool)"
+tech-stack:
+  added: []
+  patterns:
+    - "BaseModel + per-field Field(description=...) (matches existing SearchDocsResult / PackageDocsResult)"
+    - "Optional delta fields default to None / default_factory=list so the JSON diff shape is uniform across all four change cases"
+key-files:
+  created: []
+  modified:
+    - "src/mcp_server_python_docs/models.py"
+decisions:
+  - "signature_delta named per cross-AI review M1 (NOT signature_change); description marks it advisory/best-effort, not authoritative"
+  - "note: str | None added per cross-AI review M2 so the service can flag partial-data states without forcing a wrong change category"
+  - "No CompareVersionsInput model — server.py uses standalone Annotated[..., Field(...)] param aliases (matches PackageDocsInput removal audit)"
+metrics:
+  duration: ~6m
+  completed: 2026-05-28
+  tasks: 2
+  files_changed: 1
+---
+
+# Phase 09 Plan 02: result-models Summary
+
+Added the `CompareVersionsResult` Pydantic model and `ChangeKind` literal to
+`models.py` as the typed wire contract for the upcoming `compare_versions` MCP
+tool, applying the cross-AI review renames (`signature_delta`) and the new
+partial-data `note` field — locking the diff shape before Plan 03 implements the
+service.
+
+## What Was Built
+
+- **`ChangeKind`** literal alias: `Literal["added", "removed", "changed", "unchanged"]` — the diff discriminator.
+- **`CompareVersionsResult(BaseModel)`** with:
+  - Required (always populated): `symbol`, `v1`, `v2`, `change`.
+  - Optional deltas (None / empty list when not applicable to the case):
+    `new_in`, `removed_in`, `changed_in`, `deprecated_in`, `signature_delta`,
+    `see_also_added`, `see_also_removed`, `section_diff`, `note`.
+- Every field carries an explicit `Field(description=...)` so FastMCP's
+  auto-derived `outputSchema` is informative to MCP clients.
+- None-valued optionals serialize as `null` (verified via `model_dump_json`),
+  giving a predictable diff shape across all four `change` cases.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+| ---- | ---- | ------ | ----- |
+| 1 | Add CompareVersionsResult model + ChangeKind literal | `bdcde46` | src/mcp_server_python_docs/models.py |
+| 2 | Token-frugality smoke check (measurement only) | (no commit — no file changes) | — |
+
+## Verification
+
+- `uv run ruff check src/ tests/` — clean.
+- `uv run pyright src/` — 0 errors, 0 warnings.
+- `uv run pytest --tb=short -q` — 269 passed (no regressions to the existing 5-tool suite).
+- Model construct + serialize asserts pass; invalid `change='wat'` raises `pydantic.ValidationError`.
+- `grep -c "signature_change" src/mcp_server_python_docs/models.py` returns 0 (M1 rename confirmed).
+- Token-frugality smoke check: `added=266B (~66tok) changed=818B (~204tok)` — both strictly under the 300-token budget (CMPR-03). The "changed" case used a 500-char `section_diff` plus populated `signature_delta` and `note`, confirming the model accepts both new fields together.
+
+## Cross-AI Review Findings Addressed
+
+- **M1** — `signature_change` renamed to `signature_delta`; description explicitly marks it advisory ("MAY be a docstring change or prose change rather than a true signature change — treat as advisory, not authoritative"). No occurrence of `signature_change` remains in the file.
+- **M2** — Added `note: str | None = None` so the service (Plan 03) can honestly flag partial-data states (e.g. docs page not fetchable for one/both versions) without forcing the result into the wrong `change` category.
+- **L1** — Documented the `len(json.dumps(...)) // 4` byte proxy as a regression smoke check, not a token guarantee. Real token assertions live in Plan 03's test suite.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. Task 2 is a measurement-only task and
+correctly produced no source/test changes (Plan 03 owns the test suite).
+
+## Known Stubs
+
+None. The model is a typed contract with no data sources to wire in this plan;
+Plan 03 (CompareService) populates instances.
+
+## Notes for Downstream Plans
+
+- **Plan 03** can `from mcp_server_python_docs.models import CompareVersionsResult, ChangeKind` and return instances from `CompareService.compare(...)`, populating `signature_delta` and `note` directly.
+- **Plan 04** can add `CompareVersionsResult` to the existing batch import in `server.py` — no new module-level state was added to `models.py`, so there is no circular-import risk.
+- The review's HIGH finding about `test_five_tools_registered` (`assert len(tools) == 5`) is a Plan 04 concern and is untouched here; this plan adds no tool registration.
+
+## Self-Check: PASSED
+
+- FOUND: src/mcp_server_python_docs/models.py (contains `class CompareVersionsResult(BaseModel):` and `ChangeKind = Literal[...]`)
+- FOUND: commit bdcde46 (Task 1)
+- Task 2 intentionally has no commit (measurement only, no file changes) — consistent with the plan.

--- a/.planning/phases/09-compare-versions/09-03-compare-service-PLAN.md
+++ b/.planning/phases/09-compare-versions/09-03-compare-service-PLAN.md
@@ -1,0 +1,403 @@
+---
+phase: 09-compare-versions
+plan: 03
+type: execute
+wave: 1
+depends_on:
+  - 09-01-data-shape-spike
+  - 09-02-result-models
+files_modified:
+  - src/mcp_server_python_docs/services/compare.py
+  - tests/test_compare_versions.py
+autonomous: true
+requirements:
+  - CMPR-01
+  - CMPR-02
+  - CMPR-03
+must_haves:
+  truths:
+    - "`CompareService.compare(symbol, v1, v2)` returns a `CompareVersionsResult` whose `change` field is one of `added | removed | changed | unchanged`."
+    - "Algorithm ordering is FIXED per cross-AI review H2: (1) `validate_version` BOTH `v1` and `v2` first → raises `VersionNotFoundError` for unknown versions, (2) resolve symbol in BOTH versions via `create_symbol_cache`, (3) if symbol is missing in BOTH versions raise `SymbolNotFoundError`, (4) ONLY THEN handle the `v1 == v2` identical-versions case as `change='unchanged'`. Identical versions return `unchanged` ONLY when the symbol exists in that version."
+    - "Calling `compare('does.not.exist', '3.11', '3.11')` raises `SymbolNotFoundError` — NOT `change='unchanged'`. This is the explicit fix for cross-AI review H2 and prevents the false-negative where identical-versions short-circuit bypasses symbol-existence validation."
+    - "Calling `compare(symbol, '3.99', v2)` raises `VersionNotFoundError` with the message containing BOTH the missing version string `'3.99'` AND at least one currently-indexed version string (e.g. `'3.10'` and `'3.11'`) — verifying success criterion #3's actionable-error-with-list requirement (H3-related M3 fix)."
+    - "Calling `compare('asyncio.TaskGroup', '3.10', '3.11')` against the test fixture returns `change='added'` and `new_in='3.11'`."
+    - "When both versions have the symbol but `ContentService.get_docs` raises `PageNotFoundError` for one or both, the result is `change='changed'` with `section_diff=None` and `note='docs page not available for one or both versions'` — NOT `change='unchanged'`. This is the explicit fix for cross-AI review M2 (false-negative when slug/anchor mismatch hides real regressions)."
+    - "The see-also delta is real: a symbol that gains a `See also` reference between v1 and v2 produces `see_also_added != []`; the inverse produces `see_also_removed != []`. CMPR-01's see-also requirement has corresponding test coverage (per cross-AI review H3)."
+    - "The deprecation marker is real: a symbol deprecated in v2 produces `deprecated_in == '<extracted version>'`. CMPR-01's deprecation requirement has corresponding test coverage (per cross-AI review H3)."
+    - "The signature heuristic field is named `signature_delta` (NOT `signature_change`, per Plan 02 / M1) and its emission is exercised by at least two test cases: one where line 1 IS a function signature (asserts `signature_delta` is non-None and includes signature-like text), one where line 1 is prose (asserts the field is populated but documented as advisory)."
+    - "The 1200-byte byte-count ceiling in the token-frugality test is a REGRESSION SMOKE CHECK per cross-AI review L1, not a literal token guarantee. The test docstring/comment makes this explicit."
+    - "`compare.py` does NOT import `VersionNotFoundError` (per cross-AI review H4 fix option (a)) — `validate_version` raises it from its own module; tests import the exception type from `mcp_server_python_docs.errors`. This avoids ruff F401."
+    - "The serialized JSON of any returned `CompareVersionsResult` is under 1200 bytes (proxy for <300 tokens) for the headline 'added' case — assertion remains a smoke check."
+  artifacts:
+    - path: "src/mcp_server_python_docs/services/compare.py"
+      provides: "CompareService class with compare(symbol, v1, v2) method"
+      contains: "class CompareService:"
+    - path: "tests/test_compare_versions.py"
+      provides: "Pytest tests for all four diff cases, both error paths, the see-also/deprecation/signature-delta heuristic, the PageNotFoundError → changed+note fallback, and the token-frugality smoke check"
+      contains: "def test_compare_added_in_v2"
+  key_links:
+    - from: "src/mcp_server_python_docs/services/compare.py"
+      to: "src/mcp_server_python_docs/services/cache.py (create_symbol_cache)"
+      via: "import: `from mcp_server_python_docs.services.cache import create_symbol_cache`"
+      pattern: "create_symbol_cache"
+    - from: "src/mcp_server_python_docs/services/compare.py"
+      to: "src/mcp_server_python_docs/services/content.py (ContentService.get_docs)"
+      via: "constructor accepts `ContentService` instance; calls `self._content.get_docs(slug, version, anchor)`"
+      pattern: "content_service.get_docs"
+    - from: "src/mcp_server_python_docs/services/compare.py"
+      to: "src/mcp_server_python_docs/services/version_resolution.py (validate_version)"
+      via: "import: `from mcp_server_python_docs.services.version_resolution import validate_version`"
+      pattern: "validate_version"
+    - from: "src/mcp_server_python_docs/services/compare.py"
+      to: "src/mcp_server_python_docs/services/observability.py (log_tool_call)"
+      via: "decorator: `@log_tool_call('compare_versions')` on the `compare` method"
+      pattern: "@log_tool_call"
+---
+
+<objective>
+Implement `CompareService.compare(symbol, v1, v2)` in a new file `src/mcp_server_python_docs/services/compare.py` and exercise it from a new test file `tests/test_compare_versions.py`. This plan owns the core logic; Plan 04 wires it into the MCP tool surface.
+
+Purpose: Deliver the behavioral substance of Phase 09 — the four diff branches (added / removed / changed / unchanged), the three error/fallback paths (VersionNotFoundError, SymbolNotFoundError, PageNotFoundError → changed+note), the see-also/deprecation/signature-delta heuristics, and the token-frugality assertion — in one focused, testable unit, without touching server-side wiring.
+
+This plan was revised in response to cross-AI review (09-REVIEWS.md). Key changes:
+- H2: Branch ordering is validate-versions → resolve-symbols → check-both-missing → then-handle-identical-versions (NOT identical-first).
+- H3: See-also added/removed and deprecation tests added explicitly.
+- H4: `VersionNotFoundError` is NOT imported into `compare.py` — it propagates from `validate_version`.
+- M1: Field is `signature_delta`, advisory; tested with both signature-line-1 and prose-line-1 fixtures.
+- M2: `PageNotFoundError` in both-present branch returns `change='changed'` + `note=...`, not `unchanged`.
+- M3: Missing-version test asserts indexed-version list appears in the error message.
+- L1: Token-frugality test is documented as a smoke check.
+
+Output: One new service module, one new test file. All `uv run pytest tests/test_compare_versions.py -x` tests green; `uv run ruff check` and `uv run pyright src/` exit 0.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@.planning/phases/09-compare-versions/09-CONTEXT.md
+@.planning/phases/09-compare-versions/09-RESEARCH.md
+@.planning/phases/09-compare-versions/09-REVIEWS.md
+@.planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md
+@src/mcp_server_python_docs/models.py
+@src/mcp_server_python_docs/services/cache.py
+@src/mcp_server_python_docs/services/version_resolution.py
+@src/mcp_server_python_docs/services/observability.py
+@tests/test_multi_version.py
+@tests/conftest.py
+
+<interfaces>
+<!-- Existing primitives Plan 03 composes with. All HIGH confidence — verified against codebase. -->
+
+From src/mcp_server_python_docs/services/cache.py:
+```python
+class CachedSymbol(NamedTuple):
+    qualified_name: str
+    symbol_type: str
+    uri: str        # e.g. "library/asyncio-task.html#asyncio.TaskGroup"
+    anchor: str     # e.g. "asyncio.TaskGroup"
+    module: str
+    version: str
+
+def create_symbol_cache(db: sqlite3.Connection) -> Callable[[str, str], CachedSymbol | None]:
+    """LRU(128) closure: resolve_symbol(qualified_name, version) -> CachedSymbol | None."""
+```
+
+From src/mcp_server_python_docs/services/version_resolution.py:
+```python
+def validate_version(db: sqlite3.Connection, version: str) -> str:
+    """Raises VersionNotFoundError(f'version {version!r} not found; available: {available}').
+
+    The error message embeds the available-version list — directly satisfies CMPR-02 /
+    success criterion #3. Tests import VersionNotFoundError from `..errors` and pattern-match
+    BOTH the missing version AND at least one indexed version in str(exc.value).
+    """
+```
+
+From src/mcp_server_python_docs/services/content.py:
+```python
+class ContentService:
+    def __init__(self, db, persistent_cache=None): ...
+    @log_tool_call("get_docs")
+    def get_docs(self, slug, version=None, anchor=None, max_chars=8000, start_index=0) -> GetDocsResult: ...
+    # Raises PageNotFoundError when slug or (slug, anchor) is not present in the index.
+```
+
+From src/mcp_server_python_docs/models.py (added by Plan 02):
+```python
+ChangeKind = Literal["added", "removed", "changed", "unchanged"]
+
+class CompareVersionsResult(BaseModel):
+    symbol: str; v1: str; v2: str; change: ChangeKind
+    new_in: str | None = None; removed_in: str | None = None
+    changed_in: str | None = None; deprecated_in: str | None = None
+    signature_delta: str | None = None  # renamed from signature_change per M1
+    see_also_added: list[str] = Field(default_factory=list)
+    see_also_removed: list[str] = Field(default_factory=list)
+    section_diff: str | None = None
+    note: str | None = None  # new per M2
+```
+
+From src/mcp_server_python_docs/services/observability.py:
+```python
+def log_tool_call(tool_name: str) -> Callable:
+    """Decorator. Logs logfmt to stderr. Extracts `version` kwarg if present."""
+```
+
+From src/mcp_server_python_docs/errors.py:
+```python
+class VersionNotFoundError(DocsServerError): ...
+class SymbolNotFoundError(DocsServerError): ...
+class PageNotFoundError(DocsServerError): ...
+```
+
+From tests/test_multi_version.py — the fixture pattern to clone (lines 17-81):
+```python
+@pytest.fixture
+def multi_version_db(tmp_path):
+    db_path = tmp_path / "test.db"
+    conn = get_readwrite_connection(db_path)
+    bootstrap_schema(conn)
+    conn.execute("INSERT INTO doc_sets ...")  # 3.12 + 3.13
+    # insert documents, sections, symbols, rebuild FTS
+    yield conn
+    conn.close()
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Implement CompareService with FIXED branch ordering (H2) and the renamed signature_delta heuristic (M1)</name>
+  <read_first>
+    - src/mcp_server_python_docs/services/cache.py (full file — CachedSymbol shape, create_symbol_cache)
+    - src/mcp_server_python_docs/services/version_resolution.py (validate_version)
+    - src/mcp_server_python_docs/services/content.py (ContentService — for the call pattern; do NOT modify)
+    - src/mcp_server_python_docs/services/observability.py (log_tool_call decorator signature)
+    - src/mcp_server_python_docs/errors.py (VersionNotFoundError, SymbolNotFoundError, PageNotFoundError)
+    - src/mcp_server_python_docs/models.py (CompareVersionsResult from Plan 02 — including renamed `signature_delta` and new `note` fields — already in context)
+    - .planning/phases/09-compare-versions/09-01-data-shape-spike-SUMMARY.md (locked regex patterns from Wave 0 spike)
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (H2 ordering + H4 import + M1 rename + M2 fallback semantics)
+    - .planning/phases/09-compare-versions/09-RESEARCH.md (Question 2(c) — branch logic; Pitfall 2 — slug/anchor derivation; Pitfall 3 — keep sync)
+  </read_first>
+  <action>
+    Create new file `src/mcp_server_python_docs/services/compare.py`. Module docstring should reference CMPR-01/02/03 and Phase 09.
+
+    **Imports (H4 fix — drop `VersionNotFoundError`):**
+    - stdlib: `sqlite3`, `difflib`, `re`, `typing.TYPE_CHECKING`
+    - project: `CompareVersionsResult` from `..models`, `create_symbol_cache` from `.cache`, `validate_version` from `.version_resolution`, `log_tool_call` from `.observability`
+    - project errors: `SymbolNotFoundError` + `PageNotFoundError` from `..errors`. **DO NOT import `VersionNotFoundError`** — it is raised by `validate_version` from its own module; `compare.py` never references the type by name (per cross-AI review H4 option (a): tests import the exception from `..errors`, not from `compare.py`). This avoids ruff F401 unused-import.
+    - `from __future__ import annotations` (matches the rest of the codebase)
+
+    **Module-level regex constants**, copied verbatim from `09-01-data-shape-spike-SUMMARY.md ## Locked regex patterns`. If the SUMMARY records A1 as FALSIFIED, the corresponding extractor returns `None` unconditionally; document that decision in the constant's adjacent comment.
+
+    **Class `CompareService` with:**
+    - `__init__(self, db: sqlite3.Connection, content_service: ContentService)` — store `db`, store `content_service`, build `self._resolve = create_symbol_cache(db)` (own private LRU per RESEARCH §Q7 Open Question 3 resolution).
+    - `@log_tool_call("compare_versions")` decorated public method `compare(self, symbol: str, v1: str, v2: str) -> CompareVersionsResult`. Keep the method SYNC per RESEARCH Pitfall 3.
+
+    **Inside `compare` — CRITICAL: the ordering below is the H2 fix and MUST be followed exactly:**
+
+    1. **Validate BOTH versions first** (so `compare(symbol, '3.99', '3.11')` raises `VersionNotFoundError` regardless of symbol existence):
+       ```
+       validate_version(self._db, v1)
+       validate_version(self._db, v2)
+       ```
+       Each call raises `VersionNotFoundError` from its own module — `compare.py` does not reference the type.
+
+    2. **Resolve symbol in BOTH versions** (so `compare('does.not.exist', '3.11', '3.11')` can detect "missing in both" even when v1 == v2):
+       ```
+       sym_v1 = self._resolve(symbol, v1)
+       sym_v2 = self._resolve(symbol, v2)
+       ```
+
+    3. **If symbol is missing in BOTH versions** → raise `SymbolNotFoundError(f"symbol {symbol!r} not found in v{v1} or v{v2}")`. This branch fires BEFORE the v1==v2 check, so identical-versions with a non-existent symbol correctly raises rather than returning unchanged.
+
+    4. **If `v1 == v2`** (and we now know the symbol exists in at least one version, which because v1==v2 means in that one version): return `CompareVersionsResult(symbol=symbol, v1=v1, v2=v2, change="unchanged")` with all optional fields at default.
+
+    5. **Otherwise, branch on (sym_v1, sym_v2) presence:**
+       - `sym_v1 is None and sym_v2 is not None` → fetch v2 section text via `self._content.get_docs(slug=sym_v2.uri.split("#", 1)[0], version=v2, anchor=sym_v2.anchor)`. Extract `new_in` via `_NEW_IN_RE`. Return `CompareVersionsResult(symbol=symbol, v1=v1, v2=v2, change="added", new_in=<extracted or None>)`. **For the "added" branch only**, swallow `PageNotFoundError` and continue with `new_in=None` (the symbol exists in the symbols table, the section just isn't fetchable — degraded but honest; no `note` needed because the structural "added" is sound).
+
+       - `sym_v1 is not None and sym_v2 is None` → return `CompareVersionsResult(symbol=symbol, v1=v1, v2=v2, change="removed", removed_in=v2)`. No section fetch needed; the symbol's gone.
+
+       - `sym_v1 is not None and sym_v2 is not None` → fetch both sections via `ContentService.get_docs` (slug via `uri.split("#", 1)[0]`, version, anchor). **M2 fix:** if either fetch raises `PageNotFoundError`, return:
+         ```
+         CompareVersionsResult(
+             symbol=symbol, v1=v1, v2=v2,
+             change="changed",
+             section_diff=None,
+             note="docs page not available for one or both versions",
+         )
+         ```
+         Do NOT return `unchanged` (that was the previous false-negative behavior identified by review M2).
+
+         If both fetches succeed:
+         - Compute `changed_in` via `_CHANGED_IN_RE` on the v2 section text.
+         - Compute `deprecated_in` via `_DEPRECATED_IN_RE` on the v2 section text.
+         - Compute `signature_delta` (renamed per M1): look at the first non-empty line of each section text; if they differ, set `signature_delta` to a short prose label like `f"line 1 differs (v{v1}: {first_v1[:80]} → v{v2}: {first_v2[:80]})"`. Otherwise `None`. The model field's description in Plan 02 already marks this as advisory; the implementation just emits it.
+         - Compute `see_also_added` / `see_also_removed` by extracting markdown link labels (`_SEE_ALSO_LINK_RE`) from a window starting at the first case-insensitive "See also" line in each section (window size: up to next ATX heading or 20 lines). Set-difference: `see_v2 - see_v1` and `see_v1 - see_v2`. If either side has no "See also", the corresponding lists stay empty (this is the test case for H3 (b) — see-also removed). If A2 was FALSIFIED in 09-01, the extractor returns `[]` unconditionally and the see-also delta is silently empty.
+         - Compute `section_diff` via `difflib.unified_diff(v1_lines, v2_lines, lineterm="", n=2)` joined into a single string. Truncate to 600 chars. If the diff is empty (sections identical) AND no extractor produced a value AND no see-also delta exists, return `change="unchanged"`. Otherwise return `change="changed"` with whichever subset of fields are populated.
+
+    **Module-level private helpers**: `_extract_new_in(text: str) -> str | None`, `_extract_changed_in`, `_extract_deprecated_in`, `_extract_see_also(text: str) -> list[str]`. Each takes a section text string and returns the extracted value or fallback (None / []).
+
+    Do NOT add any `asyncio.to_thread` — SQLite reads on the open connection are non-blocking per RESEARCH Pitfall 3. Do NOT join `symbols.section_id` directly; always derive slug and anchor from `CachedSymbol.uri` and `CachedSymbol.anchor` per RESEARCH Pitfall 2.
+
+    Do NOT use the field name `signature_change` anywhere — Plan 02 renamed it to `signature_delta` per M1. Verify by grep: `grep -c "signature_change" src/mcp_server_python_docs/services/compare.py` MUST return 0.
+
+    Do NOT import `VersionNotFoundError` — verify by grep: `grep -c "VersionNotFoundError" src/mcp_server_python_docs/services/compare.py` MUST return 0 (per H4 option (a)).
+  </action>
+  <verify>
+    <automated>uv run ruff check src/mcp_server_python_docs/services/compare.py && uv run pyright src/mcp_server_python_docs/services/compare.py && uv run python -c "from mcp_server_python_docs.services.compare import CompareService; assert hasattr(CompareService, 'compare'); import inspect; sig=inspect.signature(CompareService.compare); assert list(sig.parameters.keys()) == ['self', 'symbol', 'v1', 'v2'], sig" && grep -c "signature_change" src/mcp_server_python_docs/services/compare.py | grep -q "^0$" && grep -c "VersionNotFoundError" src/mcp_server_python_docs/services/compare.py | grep -q "^0$"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `src/mcp_server_python_docs/services/compare.py` contains `class CompareService:` and `def compare(self, symbol: str, v1: str, v2: str) -> CompareVersionsResult:`.
+    - Source: file imports `create_symbol_cache`, `validate_version`, `log_tool_call`, `CompareVersionsResult`, `SymbolNotFoundError`, `PageNotFoundError`, `difflib`, `re`.
+    - Source: file does NOT import `VersionNotFoundError` (H4 fix). `grep -c "VersionNotFoundError" src/mcp_server_python_docs/services/compare.py` returns 0.
+    - Source: file does NOT contain the string `signature_change` (M1 rename). `grep -c "signature_change" src/mcp_server_python_docs/services/compare.py` returns 0.
+    - Source: file contains the string `signature_delta` at least once.
+    - Source: file does NOT import `asyncio`, `tiktoken`, or `anthropic`.
+    - Source: file contains the string `"docs page not available for one or both versions"` (M2 note text).
+    - Source: `grep -n "@log_tool_call" src/mcp_server_python_docs/services/compare.py` returns at least one match.
+    - Source: in the `compare` method body, `validate_version` calls for both `v1` and `v2` appear BEFORE any `self._resolve(...)` call, and the `v1 == v2` early-return appears AFTER the both-symbols-missing → `SymbolNotFoundError` raise. Verify by reading the source: the line containing `if v1 == v2:` (or equivalent) appears after the line containing `raise SymbolNotFoundError`.
+    - CLI: `uv run ruff check src/mcp_server_python_docs/services/compare.py` exits 0 (H4 verification — no F401 from unused VersionNotFoundError import).
+    - CLI: `uv run pyright src/mcp_server_python_docs/services/compare.py` exits 0.
+    - Behavior: import succeeds and `CompareService.compare`'s signature is exactly `(self, symbol, v1, v2)`.
+  </acceptance_criteria>
+  <done>The service module compiles cleanly, type-checks, exposes the documented public API with the H2 branch ordering, has no unused `VersionNotFoundError` import (H4), uses the renamed `signature_delta` field (M1), and emits the M2 note text on `PageNotFoundError` in the both-present branch.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Build the `compare_db` fixture and the FULL behavioral test suite (H2, H3, H4, M1, M2, M3, L1)</name>
+  <read_first>
+    - tests/test_multi_version.py (full file — clone the `multi_version_db` shape, line 17-81)
+    - tests/conftest.py (lines 1-220 — fixture conventions, `_STABILITY_SYMBOLS` table for inspiration)
+    - src/mcp_server_python_docs/services/compare.py (the implementation from Task 1 — already in context)
+    - src/mcp_server_python_docs/models.py (CompareVersionsResult with signature_delta and note)
+    - src/mcp_server_python_docs/errors.py (VersionNotFoundError, SymbolNotFoundError, PageNotFoundError — tests import these from here, NOT from compare.py)
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (H2, H3, M1, M2, M3, L1 — the full revision checklist)
+    - .planning/phases/09-compare-versions/09-RESEARCH.md (Question 5 — test table; Question 6 — byte-budget proxy)
+    - .planning/phases/09-compare-versions/09-CONTEXT.md (Success criteria 1, 2, 3, 4, 5)
+  </read_first>
+  <action>
+    Create new file `tests/test_compare_versions.py`. Use `from __future__ import annotations`. Imports include `from mcp_server_python_docs.errors import VersionNotFoundError, SymbolNotFoundError` (the test file imports these from `..errors`, NOT from `compare.py`, satisfying H4 option (a)).
+
+    Add an inline pytest fixture `compare_db` (do not add to conftest.py — keep it local because it's used only by this test module, matching `multi_version_db`'s inline placement). The fixture builds `tmp_path / "compare.db"` via `get_readwrite_connection` + `bootstrap_schema`, then inserts:
+
+    **Two doc_sets:** `(3.10, is_default=0)` and `(3.11, is_default=1)`.
+
+    **Symbols per version:**
+    - In 3.10: `asyncio.run` (function, uri `library/asyncio-runner.html#asyncio.run`, anchor `asyncio.run`); `json.dumps` (function, uri `library/json.html#json.dumps`, anchor `json.dumps`); `pathlib.Path` (class, uri `library/pathlib.html#pathlib.Path`, anchor `pathlib.Path`); `functools.cache` (function, uri `library/functools.html#functools.cache`, anchor `functools.cache`); `some.old_func` (function, uri `library/somemodule.html#some.old_func`, anchor `some.old_func`).
+    - In 3.11: `asyncio.run`, `json.dumps`, `pathlib.Path`, `functools.cache`, `some.old_func`, AND `asyncio.TaskGroup` (class, uri `library/asyncio-task.html#asyncio.TaskGroup`, anchor `asyncio.TaskGroup`).
+
+    **Documents + sections (one section per anchor per version):**
+    - `asyncio.run` in 3.10: `content_text = "Execute the coroutine and return the result.\n\nMore prose."`
+    - `asyncio.run` in 3.11: `content_text = "def asyncio.run(coro, *, debug=None)\n\nExecute the coroutine and return the result.\n\nChanged in version 3.10: Improved behavior."` — line 1 IS a signature (M1 test fixture).
+    - `json.dumps` in 3.10 AND 3.11: identical section `content_text = "Serialize obj to a JSON formatted str."` — triggers the unchanged-after-diff branch.
+    - `asyncio.TaskGroup` in 3.11 only: `content_text = "An asynchronous context manager holding a group of tasks.\n\nNew in version 3.11."` — triggers `_NEW_IN_RE`.
+    - `pathlib.Path` in 3.10: `content_text = "Concrete path classes.\n\nMore prose."` (no see-also)
+    - `pathlib.Path` in 3.11: `content_text = "Concrete path classes.\n\nSee also\n\n[os.path](library/os.path.html) — Operating system path manipulation.\n[fnmatch](library/fnmatch.html) — Pattern matching."` — triggers see-also-ADDED (H3 (a)).
+    - `functools.cache` in 3.10: `content_text = "Simple cache.\n\nSee also\n\n[lru_cache](library/lru_cache.html) — LRU cache."` (has see-also)
+    - `functools.cache` in 3.11: `content_text = "Simple cache.\n\nMore prose only, no see-also."` (no see-also) — triggers see-also-REMOVED (H3 (b)).
+    - `some.old_func` in 3.10: `content_text = "Old API."`
+    - `some.old_func` in 3.11: `content_text = "Old API.\n\nDeprecated since version 3.11: use new_func() instead."` — triggers `_DEPRECATED_IN_RE` (H3 (c)).
+
+    Rebuild FTS as in `multi_version_db` (the last 3 lines).
+
+    **Write the following tests (one per finding-driven case):**
+
+    1. `test_compare_added_in_v2(compare_db)` — instantiates `ContentService(compare_db)` then `CompareService(compare_db, content_svc)`, calls `compare("asyncio.TaskGroup", "3.10", "3.11")`. Asserts `result.change == "added"`, `result.symbol == "asyncio.TaskGroup"`, `result.v1 == "3.10"`, `result.v2 == "3.11"`, `result.new_in == "3.11"`. Maps to CMPR-01 + success criterion #1.
+
+    2. `test_compare_identical_versions(compare_db)` — calls `compare("json.dumps", "3.11", "3.11")`. Asserts `result.change == "unchanged"`, `result.new_in is None`, `result.section_diff is None`, `result.see_also_added == []`, `result.note is None`. Maps to success criterion #2.
+
+    3. `test_compare_changed_signature(compare_db)` — calls `compare("asyncio.run", "3.10", "3.11")`. Asserts `result.change == "changed"`, `result.changed_in == "3.10"`, and `result.signature_delta is not None`. Additionally assert `"def asyncio.run" in result.signature_delta` (the v2 section's line 1 starts with that signature, so the heuristic SHOULD include it in the delta label). Maps to CMPR-01 — the "changed" branch + M1 signature-delta-on-signature-line test.
+
+    4. `test_compare_signature_delta_documents_prose_change(compare_db)` — calls `compare("pathlib.Path", "3.10", "3.11")` (line 1 of both is "Concrete path classes." — same — so `signature_delta` should be `None`). Asserts `result.signature_delta is None`. Then construct a SECOND in-fixture variant where line 1 differs in prose only (e.g. a section whose v2 line 1 is "Concrete pathy classes."). Assert `result.signature_delta is not None` and add a code comment documenting: "The heuristic flagged a prose change — this is expected advisory behavior per M1; production callers should NOT trust signature_delta as a definitive signature change indicator." Maps to M1 — both heuristic cases tested.
+
+    5. `test_compare_see_also_added(compare_db)` — calls `compare("pathlib.Path", "3.10", "3.11")`. Asserts `result.change == "changed"`, `result.see_also_added` contains at least `"os.path"` (or both `os.path` and `fnmatch`), `result.see_also_removed == []`. Maps to CMPR-01 see-also requirement + H3 (a).
+
+    6. `test_compare_see_also_removed(compare_db)` — calls `compare("functools.cache", "3.10", "3.11")`. Asserts `result.change == "changed"`, `result.see_also_removed` contains at least `"lru_cache"`, `result.see_also_added == []`. Maps to CMPR-01 see-also requirement + H3 (b).
+
+    7. `test_compare_deprecated_in_v2(compare_db)` — calls `compare("some.old_func", "3.10", "3.11")`. Asserts `result.change == "changed"`, `result.deprecated_in == "3.11"`. Maps to CMPR-01 deprecation requirement + H3 (c).
+
+    8. `test_compare_unknown_version_raises_with_indexed_list(compare_db)` (renamed from `test_compare_unknown_version_raises` per M3 — the test MUST assert the indexed-version list appears in the error message, not just `"not found"`): uses `pytest.raises(VersionNotFoundError) as exc_info`. Calls `compare("asyncio.run", "3.99", "3.11")`. Asserts:
+       - `"3.99" in str(exc_info.value)` (the missing version is named)
+       - `"3.10" in str(exc_info.value)` (at least one indexed version is named) — success criterion #3 actionable-error-with-list
+       - `"3.11" in str(exc_info.value)` (the OTHER indexed version is also named)
+       Maps to CMPR-02 + success criterion #3 + M3.
+
+    9. `test_compare_identical_versions_missing_symbol_raises(compare_db)` (NEW per H2): uses `pytest.raises(SymbolNotFoundError)`. Calls `compare("does.not.exist", "3.11", "3.11")`. This is the critical H2 fix test — identical versions must NOT short-circuit past symbol-existence validation. Asserts the error is raised. Optional but recommended: `match="does.not.exist"` in the raises clause to verify the symbol name appears in the message.
+
+    10. `test_compare_neither_version_has_symbol(compare_db)` — `pytest.raises(SymbolNotFoundError, match="does.not.exist")`. Calls `compare("does.not.exist", "3.10", "3.11")` (different versions, neither has it). Verifies RESEARCH §Q2(c) step 7.
+
+    11. `test_compare_page_not_available_returns_changed_with_note(compare_db, monkeypatch)` (NEW per M2): the fixture inserts symbols for a fake anchor that has NO matching `documents`/`sections` row, so `ContentService.get_docs` raises `PageNotFoundError`. Alternatively, monkeypatch `ContentService.get_docs` to raise `PageNotFoundError("simulated page not found")` for one of the version calls. Call `compare("asyncio.run", "3.10", "3.11")` under that simulated condition (use a separate symbol if monkeypatching is cleaner). Asserts `result.change == "changed"`, `result.section_diff is None`, `result.note == "docs page not available for one or both versions"`. Maps to M2 — partial-data fallback is "changed + note", not "unchanged".
+
+    12. `test_compare_diff_is_token_frugal(compare_db)` — calls `compare("asyncio.TaskGroup", "3.10", "3.11")`, then `serialized = json.dumps(result.model_dump())`, then `approx_tokens = len(serialized) // 4`, asserts `approx_tokens < 300` with an informative message including byte count. Test docstring MUST state explicitly: `"This is a REGRESSION SMOKE CHECK, not a literal token guarantee. Production tokenization may differ on unicode-heavy content; the assertion catches 'result accidentally got 3x bigger' regressions (per cross-AI review L1)."` Maps to CMPR-03 + success criterion #4 + L1.
+
+    All tests run synchronously (do NOT mark with `@pytest.mark.asyncio` — `asyncio_mode="auto"` only affects async-def tests, and these are sync).
+  </action>
+  <verify>
+    <automated>uv run pytest tests/test_compare_versions.py -x -v && uv run ruff check tests/test_compare_versions.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - CLI: `uv run pytest tests/test_compare_versions.py -x -v` exits 0 (the FULL file, all 12 tests).
+    - CLI: `uv run ruff check tests/test_compare_versions.py` exits 0.
+    - Source: `tests/test_compare_versions.py` contains each of the 12 required test function names exactly (verify with `grep -c "^def test_" tests/test_compare_versions.py` returns at least 12).
+    - Source: fixture `compare_db` is defined at module scope (not in `conftest.py`).
+    - Source: test 8 (`test_compare_unknown_version_raises_with_indexed_list`) asserts BOTH the missing version `"3.99"` AND at least one indexed version `"3.10"` or `"3.11"` appear in `str(exc.value)`. Verify by grep: `grep -A 10 "def test_compare_unknown_version_raises_with_indexed_list" tests/test_compare_versions.py | grep -c "3\.10\|3\.11"` returns at least 1.
+    - Source: test 9 (`test_compare_identical_versions_missing_symbol_raises`) exists and calls `compare("does.not.exist", "3.11", "3.11")` and expects `SymbolNotFoundError`. Verify by grep: `grep -c "test_compare_identical_versions_missing_symbol_raises" tests/test_compare_versions.py` returns 1, and the test body contains both `"3.11"` and `SymbolNotFoundError`.
+    - Source: test 11 (`test_compare_page_not_available_returns_changed_with_note`) asserts `result.note == "docs page not available for one or both versions"`. Verify by grep: `grep -c "docs page not available" tests/test_compare_versions.py` returns at least 1.
+    - Source: test 12 docstring contains the phrase "regression smoke check" (case-insensitive — L1 documentation requirement).
+    - Source: tests for see-also (`test_compare_see_also_added`, `test_compare_see_also_removed`), deprecation (`test_compare_deprecated_in_v2`), and signature-delta (`test_compare_changed_signature`, `test_compare_signature_delta_documents_prose_change`) all exist (H3 + M1 verification).
+    - Behavior: the token-frugality test prints a byte count for the headline result that is under 1200 bytes.
+  </acceptance_criteria>
+  <done>All 12 tests pass, the file is ruff-clean, every cross-AI review finding (H2, H3, H4, M1, M2, M3, L1) has at least one corresponding test, and the fixture is self-contained.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Full-suite regression — no other test broke</name>
+  <read_first>
+    - AGENTS.md (Done Means section — full pytest + ruff + pyright is the phase gate)
+  </read_first>
+  <action>
+    Run the full repository test suite plus full ruff and pyright passes to confirm Plan 03's additions did not break anything. If any pre-existing test fails, do NOT silence it — record the failure in the plan SUMMARY and stop. Plan 03 is not allowed to land if it regresses any pre-existing test.
+
+    Note: `tests/test_services.py::test_five_tools_registered` will likely STILL fail at this point because Plan 04 has not yet added the 6th tool. Plan 04 owns updating that test. Plan 03's job is just to ensure NO new failures are introduced — pre-existing test counts (5 tools) are unchanged because Plan 03 doesn't touch `server.py` or `app_context.py`.
+  </action>
+  <verify>
+    <automated>uv run pytest --tb=short -q && uv run ruff check src/ tests/ && uv run pyright src/</automated>
+  </verify>
+  <acceptance_criteria>
+    - CLI: `uv run pytest --tb=short -q` exits 0 (full suite, including the new 12 tests AND the still-correct `test_five_tools_registered` because Plan 03 does not add the 6th tool yet).
+    - CLI: `uv run ruff check src/ tests/` exits 0.
+    - CLI: `uv run pyright src/` exits 0.
+  </acceptance_criteria>
+  <done>The full quality gate (AGENTS.md "Done Means") passes for Plan 03's additions in isolation. Plan 04 will re-run the same gate after wiring the tool into `server.py` and updating the 5-tools test to 6-tools.</done>
+</task>
+
+</tasks>
+
+<verification>
+- All twelve tests in `tests/test_compare_versions.py` pass.
+- `CompareService.compare` covers the four diff branches (added / removed / changed / unchanged) with the H2 ordering (validate-versions → resolve-symbol → both-missing → identical-versions).
+- The three error/fallback paths (VersionNotFoundError with indexed-list, SymbolNotFoundError including for identical-versions, PageNotFoundError → changed+note) are tested.
+- The see-also added/removed, deprecation, and signature-delta heuristics each have a passing test (H3 + M1).
+- `compare.py` does NOT import `VersionNotFoundError` (H4 ruff F401 fix verified).
+- The token-frugality byte proxy assertion passes for the headline case and is documented as a smoke check (L1).
+- The service is SYNC (no asyncio.to_thread, no async def — verified by `grep`).
+- The `@log_tool_call("compare_versions")` decorator is on the public method.
+- The full repo quality gate (ruff + pyright + pytest) is green.
+</verification>
+
+<success_criteria>
+- Plan 04 can `from mcp_server_python_docs.services.compare import CompareService` and instantiate it with `(db, content_service)` without further changes.
+- Each of the 5 CONTEXT.md success criteria has a corresponding green test command from this plan's test file.
+- Every HIGH (H2, H3, H4) and MEDIUM (M1, M2, M3) cross-AI review finding has at least one passing test or source-level assertion that closes it.
+- The `must_haves.truths` block is verifiable end-to-end by running `uv run pytest tests/test_compare_versions.py -v`.
+</success_criteria>
+
+<output>
+Create `.planning/phases/09-compare-versions/09-03-compare-service-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/09-compare-versions/09-03-compare-service-SUMMARY.md
+++ b/.planning/phases/09-compare-versions/09-03-compare-service-SUMMARY.md
@@ -1,0 +1,158 @@
+---
+phase: 09-compare-versions
+plan: 03
+subsystem: services
+tags: [compare-versions, diff, regex-extractors, difflib, mcp-service, cross-ai-review]
+
+# Dependency graph
+requires:
+  - "09-01 (locked extractor regexes: _NEW_IN_RE / _CHANGED_IN_RE / _DEPRECATED_IN_RE / _SEE_ALSO_LINK_RE + fallback policy)"
+  - "09-02 (CompareVersionsResult + ChangeKind model contract, including signature_delta and note fields)"
+provides:
+  - "CompareService class with compare(symbol, v1, v2) -> CompareVersionsResult"
+  - "Module-level extractors: _extract_new_in / _extract_changed_in / _extract_deprecated_in / _extract_see_also"
+  - "Full behavioral test suite: tests/test_compare_versions.py (12 tests) with a self-contained compare_db fixture"
+affects:
+  - "src/mcp_server_python_docs/server.py (Plan 04 wires CompareService into the MCP tool surface)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Service composes existing primitives: validate_version + create_symbol_cache + ContentService.get_docs"
+    - "Text-derived version signals (no structured signature/deprecation/see-also metadata in the index)"
+    - "FIXED branch ordering per cross-AI review H2: validate -> resolve -> both-missing -> identical-versions"
+    - "Self-contained inline pytest fixture (compare_db) mirroring multi_version_db; data-table-driven section/symbol seeding"
+
+key-files:
+  created:
+    - src/mcp_server_python_docs/services/compare.py
+    - tests/test_compare_versions.py
+  modified: []
+
+key-decisions:
+  - "H2: identical-versions ('unchanged') check runs AFTER the both-missing SymbolNotFoundError raise, so compare('does.not.exist','3.11','3.11') raises rather than returning unchanged"
+  - "H4: compare.py never imports or names VersionNotFoundError — it propagates from validate_version; the grep gate (count == 0) required rewording docstring/comments to avoid the literal type name"
+  - "M1: signature_delta is the first-non-empty-line heuristic, advisory only; tested on both a signature line and a prose-only line change"
+  - "M2: PageNotFoundError in the both-present branch returns change='changed' + note (not the prior false-negative 'unchanged')"
+
+requirements-completed: [CMPR-01, CMPR-02, CMPR-03]
+
+# Metrics
+duration: ~12min
+completed: 2026-05-28
+tasks: 3
+files_changed: 2
+---
+
+# Phase 09 Plan 03: compare-service Summary
+
+Implemented `CompareService.compare(symbol, v1, v2)` — the behavioral core of
+Phase 09 — composing `validate_version`, `create_symbol_cache`, and
+`ContentService.get_docs` into the four diff branches (added / removed / changed
+/ unchanged), the version/symbol error paths, and the see-also / deprecation /
+signature-delta text heuristics, with every cross-AI review finding (H2, H3, H4,
+M1, M2, M3, L1) closed by a passing test or source-level assertion.
+
+## What Was Built
+
+- **`src/mcp_server_python_docs/services/compare.py`** — `CompareService` with a
+  sync, `@log_tool_call("compare_versions")`-decorated `compare` method and four
+  module-level extractors using the locked 09-01 regexes. Branch ordering is the
+  H2 fix: validate both versions → resolve symbol in both → raise
+  `SymbolNotFoundError` if missing in both → only then handle `v1 == v2`.
+- **`tests/test_compare_versions.py`** — 12 tests over a self-contained
+  `compare_db` fixture (3.10 not-default, 3.11 default) seeded from data tables.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+| ---- | ---- | ------ | ----- |
+| 1 | Implement CompareService (H2 ordering, signature_delta M1) | `8bed828` | src/mcp_server_python_docs/services/compare.py |
+| 2 | Full behavioral test suite (H2/H3/H4/M1/M2/M3/L1) | `471defb` | tests/test_compare_versions.py |
+| 3 | Full-suite regression gate | (no file changes — verification only) | — |
+
+## Verification
+
+- `uv run ruff check src/ tests/` — clean.
+- `uv run pyright src/` — 0 errors, 0 warnings.
+- `uv run pytest --tb=short -q` — **281 passed** (269 prior + 12 new); no regressions.
+- `uv run pytest tests/test_compare_versions.py -q` — 12 passed.
+- Source greps: `signature_change` count 0 (M1), `VersionNotFoundError` count 0
+  in compare.py (H4), `@log_tool_call` present, M2 note text present,
+  `signature_delta` present.
+- H2 ordering confirmed by line order: `validate_version` (L153-154) →
+  `self._resolve` (L157-158) → `raise SymbolNotFoundError` (L164) → `if v1 == v2`
+  (L169).
+- `test_five_tools_registered` still passes — Plan 03 does not touch
+  `server.py`/`app_context.py`, so the 5-tool count is unchanged (Plan 04 owns
+  the bump to 6).
+
+## Cross-AI Review Findings Addressed
+
+- **H2** — Identical-versions check moved after the both-missing
+  `SymbolNotFoundError` raise. Tests `test_compare_identical_versions_missing_symbol_raises`
+  and `test_compare_neither_version_has_symbol` enforce it.
+- **H3** — See-also added (`test_compare_see_also_added`), see-also removed
+  (`test_compare_see_also_removed`), and deprecation
+  (`test_compare_deprecated_in_v2`) each have a dedicated passing test.
+- **H4** — `compare.py` neither imports nor names `VersionNotFoundError`; tests
+  import it from `..errors`. The grep gate (count == 0) is green.
+- **M1** — Field is `signature_delta` (advisory); exercised by both
+  `test_compare_changed_signature` (line 1 is a signature) and
+  `test_compare_signature_delta_documents_prose_change` (line 1 prose-only).
+- **M2** — `PageNotFoundError` in the both-present branch returns
+  `change='changed'` + the documented note; covered by
+  `test_compare_page_not_available_returns_changed_with_note`.
+- **M3** — `test_compare_unknown_version_raises_with_indexed_list` asserts both
+  the missing version (`3.99`) and both indexed versions (`3.10`, `3.11`) appear
+  in the error message.
+- **L1** — Token-frugality test is documented as a regression smoke check; the
+  headline 'added' result serializes well under 1200 bytes.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Reworded compare.py docstring/comments to satisfy the H4 grep gate (count == 0)**
+- **Found during:** Task 1 verification.
+- **Issue:** The plan's H4 acceptance criterion requires
+  `grep -c "VersionNotFoundError" src/.../compare.py` to return 0 — i.e. the
+  literal string must not appear *at all*. The initial implementation already
+  did not import the type, but three docstring/comment lines referenced it by
+  name to explain the propagation behavior, so the grep returned 3.
+- **Fix:** Reworded those three lines to describe the unknown-version error
+  without naming the type (e.g. "validate_version raises the unknown-version
+  error from its own module"). No executable behavior changed.
+- **Files modified:** src/mcp_server_python_docs/services/compare.py
+- **Verification:** `grep -c "VersionNotFoundError" ...` returns 0; ruff +
+  pyright still pass.
+- **Committed in:** `8bed828` (Task 1 commit).
+
+**Total deviations:** 1 auto-fixed (1 blocking). Cosmetic prose change only; no
+scope creep.
+
+## Known Stubs
+
+None. `CompareService` is fully wired against real SQLite reads through
+`ContentService`; the signature_delta heuristic is intentionally advisory (M1,
+documented in both the model field description and the prose-change test).
+
+## Notes for Downstream Plans
+
+- **Plan 04** can `from mcp_server_python_docs.services.compare import CompareService`
+  and instantiate `CompareService(db, content_service)` with no further changes,
+  then update `test_five_tools_registered` (5 → 6) when it registers the
+  `compare_versions` tool.
+
+## Self-Check: PASSED
+
+- FOUND: src/mcp_server_python_docs/services/compare.py (contains `class CompareService:` and `def compare(self, symbol: str, v1: str, v2: str)`)
+- FOUND: tests/test_compare_versions.py (contains `def test_compare_added_in_v2` and the `compare_db` fixture)
+- FOUND: commit 8bed828 (Task 1)
+- FOUND: commit 471defb (Task 2)
+- Task 3 intentionally has no commit (verification-only, no file changes).
+
+---
+*Phase: 09-compare-versions*
+*Completed: 2026-05-28*

--- a/.planning/phases/09-compare-versions/09-04-mcp-tool-wiring-PLAN.md
+++ b/.planning/phases/09-compare-versions/09-04-mcp-tool-wiring-PLAN.md
@@ -1,0 +1,405 @@
+---
+phase: 09-compare-versions
+plan: 04
+type: execute
+wave: 2
+depends_on:
+  - 09-02-result-models
+  - 09-03-compare-service
+files_modified:
+  - src/mcp_server_python_docs/app_context.py
+  - src/mcp_server_python_docs/server.py
+  - tests/test_services.py
+autonomous: true
+requirements:
+  - CMPR-01
+  - CMPR-02
+must_haves:
+  truths:
+    - "`AppContext` carries a `compare_service: CompareService` field that is populated by `app_lifespan` before the context is yielded."
+    - "`server.py::create_server` registers a `@mcp.tool(annotations=_TOOL_ANNOTATIONS)` decorated function named `compare_versions` that delegates to `app_ctx.compare_service.compare`."
+    - "FastMCP exposes the new tool over stdio: enumerating tools after lifespan startup lists `compare_versions` alongside the existing five tools."
+    - "Calling `compare_versions(symbol='asyncio.TaskGroup', v1='3.10', v2='3.11')` end-to-end via FastMCP returns a `CompareVersionsResult` whose JSON shape matches what `CompareService.compare` produces, with FastMCP's auto-derived `outputSchema` including the new fields."
+    - "Errors raised by `CompareService.compare` (VersionNotFoundError, SymbolNotFoundError, PageNotFoundError-fallback-as-changed-note, anything else) are converted to `ToolError(str(e))` or `ToolError(f'Internal error: {type(e).__name__}')` the same way the existing five tools handle them."
+    - "Pre-existing tool-registration tests in `tests/test_services.py` are updated to expect SIX tools (not five) per cross-AI review H1: `test_five_tools_registered` (line 450) is renamed to `test_six_tools_registered` and its assertion is `assert len(tools) == 6`. Any other partial tool-list / annotation / schema assertions that need to enumerate the new tool are updated to include `compare_versions`."
+  artifacts:
+    - path: "src/mcp_server_python_docs/app_context.py"
+      provides: "AppContext with new `compare_service: CompareService` field"
+      contains: "compare_service: CompareService"
+    - path: "src/mcp_server_python_docs/server.py"
+      provides: "compare_versions FastMCP tool registration + lifespan wiring + parameter aliases"
+      contains: "def compare_versions("
+    - path: "tests/test_services.py"
+      provides: "Updated tool-registration tests reflecting the 6-tool surface (per H1)"
+      contains: "test_six_tools_registered"
+  key_links:
+    - from: "src/mcp_server_python_docs/server.py::app_lifespan"
+      to: "src/mcp_server_python_docs/services/compare.py::CompareService"
+      via: "construction call `CompareService(db, content_svc)` and pass into `AppContext(...)`"
+      pattern: "CompareService\\("
+    - from: "src/mcp_server_python_docs/server.py::create_server"
+      to: "AppContext.compare_service"
+      via: "tool body: `app_ctx.compare_service.compare(symbol, v1, v2)`"
+      pattern: "app_ctx.compare_service.compare"
+    - from: "tests/test_services.py (TestToolRegistration class)"
+      to: "src/mcp_server_python_docs/server.py::compare_versions"
+      via: "Updated assertions for the 6-tool surface"
+      pattern: "assert len\\(tools\\) == 6"
+---
+
+<objective>
+Wire `CompareService` into FastMCP: add the field to `AppContext`, construct the service in `app_lifespan`, register the new `@mcp.tool` block in `create_server`, add the two new parameter aliases (`SymbolParam`, `CompareVersionParam`), AND update `tests/test_services.py` so the tool-registration tests reflect the 6-tool surface (cross-AI review H1).
+
+Purpose: Make `compare_versions` callable from real MCP clients (Claude Desktop, Cursor, MCP Inspector) AND keep the existing test suite green by updating the hardcoded 5-tool assertions. All the behavioral substance shipped in Plan 03; this plan is the thin DI + decorator layer that exposes it plus the test-fixture catch-up.
+
+Output: Three file modifications — `app_context.py` (one new field), `server.py` (two new parameter aliases, one new lifespan construction line, one updated `AppContext(...)` call, one new `@mcp.tool` block, one updated batch import), and `tests/test_services.py` (rename `test_five_tools_registered` → `test_six_tools_registered`, bump the count assertion to 6, and extend any tool-list / annotation / schema assertions in `TestToolRegistration` that name tools explicitly to include `compare_versions`). Existing five tools' behavior and other tests remain unchanged.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@.planning/phases/09-compare-versions/09-CONTEXT.md
+@.planning/phases/09-compare-versions/09-RESEARCH.md
+@.planning/phases/09-compare-versions/09-REVIEWS.md
+@src/mcp_server_python_docs/app_context.py
+@src/mcp_server_python_docs/server.py
+@src/mcp_server_python_docs/services/compare.py
+@tests/test_services.py
+
+<interfaces>
+<!-- Existing AppContext shape (verified May 26, 2026). -->
+
+From src/mcp_server_python_docs/app_context.py (current — full file):
+```python
+@dataclass
+class AppContext:
+    db: sqlite3.Connection
+    index_path: Path
+    search_service: SearchService
+    content_service: ContentService
+    version_service: VersionService
+    package_docs_service: PackageDocsService = field(default_factory=PackageDocsService)
+    persistent_docs_cache: PersistentDocsCache | None = None
+    synonyms: dict[str, list[str]] = field(default_factory=dict)
+    detected_python_version: str | None = None
+    detected_python_source: str | None = None
+```
+
+From src/mcp_server_python_docs/server.py — three hook points:
+
+(1) The existing service constructions in app_lifespan (lines 154-162):
+```python
+search_svc = SearchService(db, synonyms)
+content_svc = ContentService(db, persistent_cache=persistent_docs_cache)
+version_svc = VersionService(db)
+package_docs_svc = PackageDocsService()
+```
+
+(2) The AppContext yield in app_lifespan (lines 179-191) — needs one new kwarg.
+
+(3) The tool registration cluster in create_server (lines 280-376). Existing five tools all use this pattern. The new tool slots in immediately before the final `return mcp` on line 383.
+
+Existing shared annotations (lines 214-225) — REUSE `_TOOL_ANNOTATIONS`:
+```python
+_TOOL_ANNOTATIONS = ToolAnnotations(
+    readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False,
+)
+```
+
+Existing parameter alias pattern (lines 227-270) — add two new aliases at module scope:
+```python
+# Existing:
+SearchQueryParam = Annotated[str, Field(max_length=500, description="...")]
+VersionParam = Annotated[str | None, Field(description="...")]
+PackageParam = Annotated[str, Field(min_length=1, max_length=214, description="...")]
+
+# NEW (Plan 04):
+SymbolParam = Annotated[str, Field(min_length=1, max_length=200, description="Qualified Python symbol name, e.g. 'asyncio.TaskGroup'")]
+CompareVersionParam = Annotated[str, Field(description="Python version string, e.g. '3.11'")]
+```
+
+Existing tool body template (lines 280-299, `search_docs`):
+```python
+@mcp.tool(annotations=_TOOL_ANNOTATIONS)
+def search_docs(query, version=None, kind="auto", max_results=5, ctx: Context = None):
+    app_ctx: AppContext = ctx.request_context.lifespan_context
+    try:
+        return app_ctx.search_service.search(query, version, kind, max_results)
+    except DocsServerError as e:
+        raise ToolError(str(e))
+    except Exception as e:
+        logger.exception("Unexpected error in search_docs")
+        raise ToolError(f"Internal error: {type(e).__name__}")
+```
+
+From tests/test_services.py (current state — TestToolRegistration class around lines 408-515):
+```python
+class TestToolRegistration:
+    def test_create_server_has_three_tools(self):  # Misnamed — actually checks 3 specific tools exist
+        server = create_server()
+        tools = server._tool_manager._tools
+        tool_names = set(tools.keys())
+        assert "search_docs" in tool_names
+        assert "get_docs" in tool_names
+        assert "list_versions" in tool_names
+
+    def test_all_tools_have_annotations(self):
+        server = create_server()
+        tools = server._tool_manager._tools
+        for name in ["search_docs", "get_docs", "list_versions"]:  # partial list — must add compare_versions
+            tool = tools[name]
+            annotations = tool.annotations
+            assert annotations.readOnlyHint is True
+            # ... etc
+
+    def test_five_tools_registered(self):  # <-- LINE 450 — the H1 finding
+        server = create_server()
+        tools = server._tool_manager._tools
+        assert len(tools) == 5  # <-- breaks after Plan 04 adds the 6th tool
+
+    def test_runtime_tool_schemas_include_input_constraints(self):
+        # ... enumerates specific schemas; check whether compare_versions needs an entry here
+```
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add `compare_service` field to AppContext</name>
+  <read_first>
+    - src/mcp_server_python_docs/app_context.py (full file — already in context)
+    - src/mcp_server_python_docs/services/compare.py (from Plan 03 — constructor signature is `__init__(self, db, content_service)`)
+  </read_first>
+  <action>
+    Modify `src/mcp_server_python_docs/app_context.py`. Add one import line: `from mcp_server_python_docs.services.compare import CompareService` (insert it alphabetically among the existing service imports — between `.content` and `.package_docs` lines). Add one new field to the `AppContext` dataclass, placed immediately after `content_service: ContentService` (line 27) — that placement matches the lifespan construction order: `compare_service: CompareService`. The field is required (no default) — it must be passed explicitly by `app_lifespan`. Do not reorder existing fields. Do not change defaults or types of existing fields.
+  </action>
+  <verify>
+    <automated>uv run ruff check src/mcp_server_python_docs/app_context.py && uv run pyright src/mcp_server_python_docs/app_context.py && uv run python -c "from mcp_server_python_docs.app_context import AppContext; import dataclasses; fields={f.name for f in dataclasses.fields(AppContext)}; assert 'compare_service' in fields, fields; print('AppContext fields:', sorted(fields))"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `src/mcp_server_python_docs/app_context.py` contains `from mcp_server_python_docs.services.compare import CompareService`.
+    - Source: `src/mcp_server_python_docs/app_context.py` contains `compare_service: CompareService`.
+    - CLI: `uv run ruff check src/mcp_server_python_docs/app_context.py` exits 0.
+    - CLI: `uv run pyright src/mcp_server_python_docs/app_context.py` exits 0.
+    - Behavior: `dataclasses.fields(AppContext)` includes a field named `compare_service`.
+  </acceptance_criteria>
+  <done>The dataclass schema is updated and the new import resolves cleanly; pyright agrees the field is typed `CompareService`.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Construct CompareService in app_lifespan and pass it into AppContext</name>
+  <read_first>
+    - src/mcp_server_python_docs/server.py lines 115-211 (the `app_lifespan` async context manager — already in context)
+    - src/mcp_server_python_docs/services/compare.py (from Plan 03 — `CompareService.__init__(self, db, content_service)`)
+  </read_first>
+  <action>
+    Modify `src/mcp_server_python_docs/server.py`. In `app_lifespan` (~line 115), in the service construction block (currently lines 159-162: `search_svc = ...; content_svc = ...; version_svc = ...; package_docs_svc = ...`), insert one new line: `compare_svc = CompareService(db, content_svc)`. Place it immediately after `content_svc = ...` and before `version_svc = ...` to match the dataclass field order. Add the import: `from mcp_server_python_docs.services.compare import CompareService` (insert near the other `services.` imports at the top of the file). In the `yield AppContext(...)` call (lines 180-191), add the kwarg `compare_service=compare_svc` in the position matching the dataclass field order (after `content_service=content_svc`).
+  </action>
+  <verify>
+    <automated>uv run ruff check src/mcp_server_python_docs/server.py && uv run pyright src/mcp_server_python_docs/server.py && grep -nE "compare_svc\s*=\s*CompareService\(db, content_svc\)" src/mcp_server_python_docs/server.py && grep -nE "compare_service\s*=\s*compare_svc" src/mcp_server_python_docs/server.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `src/mcp_server_python_docs/server.py` contains the line `compare_svc = CompareService(db, content_svc)` inside `app_lifespan`.
+    - Source: `src/mcp_server_python_docs/server.py` contains `compare_service=compare_svc` inside the `AppContext(...)` constructor call.
+    - Source: `src/mcp_server_python_docs/server.py` contains `from mcp_server_python_docs.services.compare import CompareService`.
+    - CLI: `uv run ruff check src/mcp_server_python_docs/server.py` exits 0.
+    - CLI: `uv run pyright src/mcp_server_python_docs/server.py` exits 0.
+  </acceptance_criteria>
+  <done>Lifespan construction and AppContext kwarg are wired; the file passes ruff and pyright.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add parameter aliases and the `compare_versions` @mcp.tool block</name>
+  <read_first>
+    - src/mcp_server_python_docs/server.py lines 213-383 (param aliases + create_server with the five existing tools)
+    - src/mcp_server_python_docs/models.py (CompareVersionsResult — added by Plan 02 with renamed `signature_delta` and new `note` field)
+    - .planning/phases/09-compare-versions/09-RESEARCH.md Q7(c) — the byte-for-byte tool block template
+  </read_first>
+  <action>
+    Modify `src/mcp_server_python_docs/server.py`. (a) After the existing param alias block (the last alias is `PackageParam` ending around line 270), add the two new aliases:
+    `SymbolParam = Annotated[str, Field(min_length=1, max_length=200, description="Qualified Python symbol name, e.g. 'asyncio.TaskGroup'")]`
+    `CompareVersionParam = Annotated[str, Field(description="Python version string, e.g. '3.11'")]`
+
+    (b) In the module-level batch import from `mcp_server_python_docs.models` (around line 30-40), add `CompareVersionsResult` to the imported names alphabetically (between existing entries — the exact line depends on current alphabetical position).
+
+    (c) In `create_server()`, immediately BEFORE the existing `# SRVR-07: _meta hint for get_docs tool.` comment (currently around line 377) and AFTER the `detect_python_version` tool block (ends at ~line 375), insert a new `@mcp.tool(annotations=_TOOL_ANNOTATIONS)` block following the byte-for-byte template from RESEARCH §Q7(c):
+
+    Decorator: `@mcp.tool(annotations=_TOOL_ANNOTATIONS)` (NOT `_PYPI_TOOL_ANNOTATIONS` — compare_versions is closed-world).
+
+    Function signature: `def compare_versions(symbol: SymbolParam, v1: CompareVersionParam, v2: CompareVersionParam, ctx: Context = None)  # type: ignore[assignment]` returning `CompareVersionsResult`.
+
+    Docstring: short — "Diff a Python stdlib symbol between two indexed versions. Returns `change=added|removed|changed|unchanged` with optional `new_in`, `changed_in`, `deprecated_in`, `signature_delta` (advisory), `see_also_added/removed`, `section_diff`, and `note` fields. Both versions must be indexed; otherwise an actionable error names the available versions." (Note: docstring lists `signature_delta` per Plan 02's M1 rename — NOT `signature_change`.)
+
+    Body — verbatim shape from the existing `search_docs` tool:
+    - `app_ctx: AppContext = ctx.request_context.lifespan_context`
+    - `try: return app_ctx.compare_service.compare(symbol, v1, v2)`
+    - `except DocsServerError as e: raise ToolError(str(e))`
+    - `except Exception as e: logger.exception("Unexpected error in compare_versions"); raise ToolError(f"Internal error: {type(e).__name__}")`
+
+    Do NOT add any `asyncio.to_thread` (compare_versions is pure SQLite reads per RESEARCH Pitfall 3; matches `search_docs` / `get_docs` shape, not `lookup_package_docs` which IS async because it does network I/O).
+  </action>
+  <verify>
+    <automated>uv run ruff check src/mcp_server_python_docs/server.py && uv run pyright src/mcp_server_python_docs/server.py && grep -nE "^def compare_versions\(|    def compare_versions\(" src/mcp_server_python_docs/server.py && grep -nE "SymbolParam = Annotated\[str" src/mcp_server_python_docs/server.py && grep -nE "CompareVersionParam = Annotated\[str" src/mcp_server_python_docs/server.py && grep -nE "from mcp_server_python_docs.models import" src/mcp_server_python_docs/server.py | head -1 && grep -c "CompareVersionsResult" src/mcp_server_python_docs/server.py</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `src/mcp_server_python_docs/server.py` contains `def compare_versions(` exactly once.
+    - Source: `src/mcp_server_python_docs/server.py` contains `SymbolParam = Annotated[str` and `CompareVersionParam = Annotated[str` exactly once each.
+    - Source: `src/mcp_server_python_docs/server.py` imports `CompareVersionsResult` from `mcp_server_python_docs.models`.
+    - Source: the new tool function uses `@mcp.tool(annotations=_TOOL_ANNOTATIONS)` (not `_PYPI_TOOL_ANNOTATIONS`). Verify: `grep -B1 "def compare_versions(" src/mcp_server_python_docs/server.py | grep -q "_TOOL_ANNOTATIONS"` and that grep does NOT match `_PYPI_TOOL_ANNOTATIONS`.
+    - Source: the new tool function returns `CompareVersionsResult` (verified by `grep -A1 "def compare_versions(" src/mcp_server_python_docs/server.py | grep "CompareVersionsResult"`).
+    - Source: the new tool function is SYNC (uses `def`, not `async def`). Verify: `grep -E "(async )?def compare_versions\(" src/mcp_server_python_docs/server.py` matches only `def compare_versions(`.
+    - Source: the docstring or signature does not contain the deprecated name `signature_change` (M1 — Plan 02 renamed it). Verify: `grep -A 5 "def compare_versions(" src/mcp_server_python_docs/server.py | grep -c "signature_change"` returns 0.
+    - CLI: `uv run ruff check src/mcp_server_python_docs/server.py` exits 0.
+    - CLI: `uv run pyright src/mcp_server_python_docs/server.py` exits 0.
+  </acceptance_criteria>
+  <done>The tool block compiles cleanly, the import is in place, and the param aliases are defined.</done>
+</task>
+
+<task type="auto">
+  <name>Task 4: Update `tests/test_services.py` for the 6-tool surface (H1 — the critical regression fix)</name>
+  <read_first>
+    - tests/test_services.py lines 405-515 (the full `TestToolRegistration` class — already in context: includes `test_create_server_has_three_tools`, `test_all_tools_have_annotations`, `test_five_tools_registered` (line 450 — the H1 target), and `test_runtime_tool_schemas_include_input_constraints`)
+    - src/mcp_server_python_docs/server.py (after Tasks 2-3 edits — already in context; confirm the tool name is exactly `compare_versions`)
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (H1 — the explicit pre-existing-test-fail risk)
+  </read_first>
+  <action>
+    Modify `tests/test_services.py` to keep the `TestToolRegistration` class green after Phase 09 adds the 6th tool.
+
+    **Edit 1 (the H1 core fix) — `test_five_tools_registered` → `test_six_tools_registered`:**
+
+    Currently (line 450-455):
+    ```python
+    def test_five_tools_registered(self):
+        from mcp_server_python_docs.server import create_server
+        server = create_server()
+        tools = server._tool_manager._tools
+        assert len(tools) == 5
+    ```
+
+    Rename to `test_six_tools_registered` and bump the count assertion to 6:
+    ```python
+    def test_six_tools_registered(self):
+        from mcp_server_python_docs.server import create_server
+        server = create_server()
+        tools = server._tool_manager._tools
+        assert len(tools) == 6
+    ```
+
+    **Edit 2 — `test_all_tools_have_annotations` (line 431-448):**
+
+    The for-loop iterates over `["search_docs", "get_docs", "list_versions"]` — a partial list. Since `compare_versions` uses the same `_TOOL_ANNOTATIONS` (readOnlyHint=True, destructiveHint=False, openWorldHint=False), add it to the list:
+    ```python
+    for name in ["search_docs", "get_docs", "list_versions", "compare_versions"]:
+    ```
+
+    Do NOT also add `lookup_package_docs` or `detect_python_version` to this loop — `lookup_package_docs` uses `_PYPI_TOOL_ANNOTATIONS` (openWorldHint=True) and would fail the assertion; pre-existing partial coverage is not this plan's job to expand.
+
+    **Edit 3 — `test_runtime_tool_schemas_include_input_constraints` (line 457-478):**
+
+    The test enumerates `search_docs` and `get_docs` schemas explicitly. Add lightweight schema assertions for `compare_versions` so a regression in its `SymbolParam`/`CompareVersionParam` constraints is caught:
+    ```python
+    compare_versions = schemas["compare_versions"]["properties"]
+    assert compare_versions["symbol"]["maxLength"] == 200
+    assert compare_versions["symbol"]["minLength"] == 1
+    # v1 and v2 do not have min/max length constraints by current design — just assert they exist
+    assert "v1" in compare_versions
+    assert "v2" in compare_versions
+    ```
+
+    **Edit 4 (do NOT make) — `test_create_server_has_three_tools` (line 411-419):**
+
+    This test asserts a SUBSET of tools by name (`search_docs`, `get_docs`, `list_versions` ARE all in the registry). It does NOT assert `len == 3`. It will continue to pass after Phase 09 adds `compare_versions`. Do NOT modify it; doing so risks expanding scope. (The test name is misleading — it's really a "these three specific tools exist" test, not a count test.)
+
+    **Final source check:** After all edits, the file must have:
+    - Zero occurrences of `assert len(tools) == 5` (verify: `grep -c "assert len(tools) == 5" tests/test_services.py` returns 0)
+    - Exactly one occurrence of `assert len(tools) == 6` (verify: `grep -c "assert len(tools) == 6" tests/test_services.py` returns 1)
+    - Zero occurrences of `test_five_tools_registered` (renamed away)
+    - Exactly one occurrence of `test_six_tools_registered`
+    - At least one mention of `compare_versions` in `TestToolRegistration` (the assertions in Edits 2 and 3)
+  </action>
+  <verify>
+    <automated>uv run pytest tests/test_services.py::TestToolRegistration -x -v && grep -c "assert len(tools) == 5" tests/test_services.py | grep -q "^0$" && grep -c "assert len(tools) == 6" tests/test_services.py | grep -q "^1$" && grep -c "test_five_tools_registered" tests/test_services.py | grep -q "^0$" && grep -c "test_six_tools_registered" tests/test_services.py | grep -q "^1$" && grep -c "compare_versions" tests/test_services.py | grep -qE "^[1-9][0-9]*$"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `tests/test_services.py` no longer contains `assert len(tools) == 5` (zero matches).
+    - Source: `tests/test_services.py` contains `assert len(tools) == 6` exactly once.
+    - Source: `tests/test_services.py` no longer contains `test_five_tools_registered` (zero matches).
+    - Source: `tests/test_services.py` contains `test_six_tools_registered` exactly once.
+    - Source: `tests/test_services.py` `test_all_tools_have_annotations` iterates over a list that includes `"compare_versions"`.
+    - Source: `tests/test_services.py` `test_runtime_tool_schemas_include_input_constraints` enumerates `schemas["compare_versions"]["properties"]` with at least one `assert` on its constraints.
+    - CLI: `uv run pytest tests/test_services.py::TestToolRegistration -x -v` exits 0 (the WHOLE class is green — H1 closed).
+    - CLI: `uv run ruff check tests/test_services.py` exits 0.
+  </acceptance_criteria>
+  <done>`TestToolRegistration` reflects the 6-tool surface; the H1 finding is fully closed.</done>
+</task>
+
+<task type="auto">
+  <name>Task 5: In-process MCP smoke test — tool is enumerable and callable</name>
+  <read_first>
+    - src/mcp_server_python_docs/server.py (after edits from Tasks 2-3 — already in context)
+    - tests/test_multi_version.py (lines 17-81 — fixture pattern to clone for a real lifespan-backed db)
+    - Any existing test that exercises FastMCP via `create_server()` directly. If none exists, fall back to enumerating registered tools via the `mcp.tool_manager`/`tool_registry` surface as recently as FastMCP 1.27 exposes (the MCP SDK is pinned `mcp>=1.27.0,<2.0.0` — check `uv run python -c "from mcp.server.fastmcp import FastMCP; help(FastMCP)"` if uncertain).
+  </read_first>
+  <action>
+    Run a quick in-process verification that does NOT require a live `index.db` (uses the `compare_db` fixture pattern instead). Two acceptable shapes:
+
+    Option A — enumerate via FastMCP introspection: `uv run python -c "from mcp_server_python_docs.server import create_server; mcp = create_server(); tools = ...; assert 'compare_versions' in [t.name for t in tools]"`. The exact attribute path depends on FastMCP 1.27. Acceptable surfaces include `mcp._tool_manager._tools` or `await mcp.list_tools()` — pick the one that already works for the project (read `tests/` for existing patterns first; if FastMCP exposes only an async `list_tools`, run it under `asyncio.run`).
+
+    Option B — if introspection is impractical, run the existing stdio smoke test suite (if present under `tests/`, look for files containing `subprocess.Popen` + `python-docs-mcp-server`). The stdio test exercises the real `tools/list` over the MCP protocol; if it lists `compare_versions`, the registration works.
+
+    If neither path is workable in <10 minutes of effort, document why in the SUMMARY and rely on the manual integration check Plan 05 adds to `.github/INTEGRATION-TEST.md` instead. Do not block on a brittle introspection check.
+  </action>
+  <verify>
+    <automated>uv run python -c "import asyncio; from mcp_server_python_docs.server import create_server; mcp = create_server(); tools = asyncio.run(mcp.list_tools()); names = [t.name for t in tools]; assert 'compare_versions' in names, names; print('Tools registered:', sorted(names))"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Behavior: the verify command exits 0 and prints `Tools registered:` followed by a list containing `compare_versions` and the five existing tools (`search_docs`, `get_docs`, `lookup_package_docs`, `list_versions`, `detect_python_version`).
+    - If the introspection command fails because FastMCP's introspection surface differs from `list_tools()`, the executor must (a) inspect FastMCP 1.27's actual API via `uv run python -c "import mcp.server.fastmcp as m; print(dir(m.FastMCP))"`, (b) substitute the working attribute, (c) leave a note in the SUMMARY explaining the substitution.
+  </acceptance_criteria>
+  <done>An in-process enumeration confirms `compare_versions` is registered alongside the five existing tools, OR the SUMMARY explicitly documents why the in-process check was skipped and defers verification to Plan 05's INTEGRATION-TEST entry.</done>
+</task>
+
+<task type="auto">
+  <name>Task 6: Full regression — every existing test still passes (including the updated 6-tools test)</name>
+  <read_first>
+    - AGENTS.md (Done Means — `pytest`, `ruff`, `pyright`)
+  </read_first>
+  <action>
+    Run the full quality gate. Plan 04's surgical edits to `app_context.py`, `server.py`, AND `tests/test_services.py` could plausibly break the existing AppContext-construction smoke tests, stdio smoke tests, or any test that inspects the tool list. Confirm none break.
+  </action>
+  <verify>
+    <automated>uv run pytest --tb=short -q && uv run ruff check src/ tests/ && uv run pyright src/</automated>
+  </verify>
+  <acceptance_criteria>
+    - CLI: `uv run pytest --tb=short -q` exits 0 (full suite — must include Plan 03's `tests/test_compare_versions.py` AND every pre-existing test AND the updated `test_six_tools_registered`).
+    - CLI: `uv run ruff check src/ tests/` exits 0.
+    - CLI: `uv run pyright src/` exits 0.
+  </acceptance_criteria>
+  <done>Full quality gate is green. Phase 09 is feature-complete in code; Plan 05 finishes user-facing docs.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `compare_versions` appears in FastMCP's registered tools list.
+- AppContext has a typed `compare_service` field constructed in `app_lifespan`.
+- `tests/test_services.py::TestToolRegistration` is green for the 6-tool surface (H1 closed).
+- Existing five tools and their tests are byte-identical (no accidental edits) outside the surgical H1 fix.
+- Full quality gate (pytest + ruff + pyright) passes.
+</verification>
+
+<success_criteria>
+- `uv run python-docs-mcp-server --help` (or equivalent FastMCP introspection) shows six tools total.
+- Real MCP clients (Claude Desktop, Cursor, Inspector) can call `compare_versions` after the server restarts — verified end-to-end by Plan 05's INTEGRATION-TEST entry.
+- No existing tool's behavior changed.
+- The pre-existing 5-tool hardcoded assertion is gone (H1 closed).
+</success_criteria>
+
+<output>
+Create `.planning/phases/09-compare-versions/09-04-mcp-tool-wiring-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/09-compare-versions/09-04-mcp-tool-wiring-SUMMARY.md
+++ b/.planning/phases/09-compare-versions/09-04-mcp-tool-wiring-SUMMARY.md
@@ -1,0 +1,157 @@
+---
+phase: 09-compare-versions
+plan: 04
+subsystem: server
+tags: [compare-versions, mcp-tool, fastmcp, dependency-injection, tool-registration, cross-ai-review]
+
+# Dependency graph
+requires:
+  - "09-02 (CompareVersionsResult + ChangeKind model contract)"
+  - "09-03 (CompareService.compare(symbol, v1, v2) -> CompareVersionsResult)"
+provides:
+  - "AppContext.compare_service: CompareService field (required, lifespan-populated)"
+  - "compare_versions FastMCP tool registered over stdio (6th tool)"
+  - "SymbolParam / CompareVersionParam parameter aliases"
+  - "tests/test_services.py TestToolRegistration updated to the 6-tool surface (H1 closed)"
+affects:
+  - ".github/INTEGRATION-TEST.md + README (Plan 05 documents the new tool end-to-end)"
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns:
+    - "Thin server layer: tool body delegates to app_ctx.compare_service.compare with DocsServerError->ToolError(str(e)) + generic Internal error mapping (matches search_docs)"
+    - "Sync @mcp.tool (no asyncio.to_thread) — compare_versions is pure SQLite reads, matching search_docs/get_docs (not lookup_package_docs which is async network I/O)"
+    - "_TOOL_ANNOTATIONS (closed-world, readOnly) reused — NOT _PYPI_TOOL_ANNOTATIONS"
+    - "Required (no-default) dataclass field placed among the other no-default service fields, before the first defaulted field"
+
+key-files:
+  created:
+    - .planning/phases/09-compare-versions/09-04-mcp-tool-wiring-SUMMARY.md
+  modified:
+    - src/mcp_server_python_docs/app_context.py
+    - src/mcp_server_python_docs/server.py
+    - tests/test_services.py
+    - tests/test_retrieval_regression.py
+
+key-decisions:
+  - "H1 closed: test_five_tools_registered renamed to test_six_tools_registered (assert len(tools) == 6); annotation loop + schema assertions extended to compare_versions"
+  - "compare_versions uses _TOOL_ANNOTATIONS (closed-world) — it reads only the local index, never the network"
+  - "Tool is SYNC (def, not async def) — pure SQLite reads, no to_thread wrapper"
+  - "Docstring uses signature_delta (Plan 02 M1 rename), never the deprecated signature_change"
+
+requirements-completed: [CMPR-01, CMPR-02]
+
+# Metrics
+duration: ~7min
+completed: 2026-05-28
+tasks: 6
+files_changed: 4
+---
+
+# Phase 09 Plan 04: mcp-tool-wiring Summary
+
+Wired `CompareService` into the FastMCP server surface: added the required
+`compare_service` field to `AppContext`, constructed it in `app_lifespan`,
+registered the sync `compare_versions` `@mcp.tool` block (with two new parameter
+aliases), and updated `tests/test_services.py` to the 6-tool surface — closing
+cross-AI review finding H1 (the hardcoded 5-tool assertion). `compare_versions`
+is now enumerable and callable over stdio alongside the five existing tools.
+
+## What Was Built
+
+- **`src/mcp_server_python_docs/app_context.py`** — one new import
+  (`CompareService`) and one new required field `compare_service: CompareService`
+  placed after `content_service` and before `version_service` (matches lifespan
+  construction order; sits among the no-default fields).
+- **`src/mcp_server_python_docs/server.py`** — `CompareVersionsResult` import,
+  `CompareService` import, `compare_svc = CompareService(db, content_svc)` in
+  `app_lifespan`, `compare_service=compare_svc` in the `AppContext(...)` yield,
+  two new parameter aliases (`SymbolParam` max_length=200/min_length=1,
+  `CompareVersionParam`), and a sync `@mcp.tool(annotations=_TOOL_ANNOTATIONS)`
+  `compare_versions` block delegating to `app_ctx.compare_service.compare` with
+  the standard `DocsServerError -> ToolError(str(e))` + generic
+  `Internal error: {type}` mapping.
+- **`tests/test_services.py`** — H1 fix: `test_five_tools_registered` renamed to
+  `test_six_tools_registered` (`assert len(tools) == 6`); `compare_versions`
+  added to the `test_all_tools_have_annotations` loop; `compare_versions` schema
+  constraints (`symbol` min/max length, `v1`/`v2` presence) asserted in
+  `test_runtime_tool_schemas_include_input_constraints`.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+| ---- | ---- | ------ | ----- |
+| 1 | Add compare_service field to AppContext | `9f63623` | src/mcp_server_python_docs/app_context.py |
+| 2 | Construct CompareService in app_lifespan + pass into AppContext | `4ced01a` | src/mcp_server_python_docs/server.py |
+| 3 | Param aliases + compare_versions @mcp.tool block | `89e4a2d` | src/mcp_server_python_docs/server.py |
+| 4 | Update tests/test_services.py to 6-tool surface (H1) | `c15e328` | tests/test_services.py |
+| 5 | In-process MCP smoke test (enumerate tools) | (no file changes — verification only) | — |
+| 6 | Full regression gate + deviation fix | `13fe752` | tests/test_retrieval_regression.py |
+
+## Verification
+
+- `uv run ruff check src/ tests/` — clean.
+- `uv run pyright src/` — 0 errors, 0 warnings.
+- `uv run pytest --tb=short -q` — **281 passed** (no regressions).
+- `uv run pytest tests/test_services.py::TestToolRegistration -x` — 6 passed (H1 closed).
+- Task 5 enumeration: `Tools registered: ['compare_versions', 'detect_python_version', 'get_docs', 'list_versions', 'lookup_package_docs', 'search_docs']` — six tools, `compare_versions` present.
+- Source greps: `compare_versions` defined once (sync `def`), uses `_TOOL_ANNOTATIONS` (not `_PYPI_TOOL_ANNOTATIONS`), returns `CompareVersionsResult`, docstring has zero `signature_change` occurrences (M1). `assert len(tools) == 5` count 0; `assert len(tools) == 6` count 1; `test_five_tools_registered` count 0; `test_six_tools_registered` count 1.
+
+## Cross-AI Review Findings Addressed
+
+- **H1** — The pre-existing hardcoded 5-tool assertion is gone. `test_six_tools_registered`
+  asserts `len(tools) == 6`; the annotation-check loop and the runtime-schema test both
+  enumerate `compare_versions`. The whole `TestToolRegistration` class is green.
+
+## Deviations from Plan
+
+### Auto-fixed Issues
+
+**1. [Rule 3 - Blocking] Updated tests/test_retrieval_regression.py for the new required AppContext field**
+- **Found during:** Task 6 (full regression gate).
+- **Issue:** `tests/test_retrieval_regression.py::_make_app_context` constructs
+  `AppContext(...)` directly. Task 1 made `compare_service` a required (no-default)
+  field, so the helper raised
+  `TypeError: AppContext.__init__() missing 1 required positional argument: 'compare_service'`,
+  failing `test_retrieval_regression_cases[local_version_defaulting]`.
+- **Fix:** Imported `CompareService`, hoisted `content_service` into a local, and passed
+  `compare_service=CompareService(db, content_service)` into the helper's `AppContext(...)`
+  (matching the lifespan field order). No production behavior changed; this is a test-fixture
+  catch-up directly caused by Task 1's required field — analogous to the H1 catch-up.
+- **Files modified:** tests/test_retrieval_regression.py
+- **Verification:** Full suite 281 passed; ruff + pyright clean.
+- **Committed in:** `13fe752` (Task 6 commit).
+
+This was the only AppContext-direct-construction site in `tests/` (verified via
+`grep -rn "AppContext(" tests/`). All other tests go through `create_server()` /
+`app_lifespan`, so no further fixture updates were needed.
+
+**Total deviations:** 1 auto-fixed (1 blocking). Test-fixture catch-up only; no scope creep.
+
+## Known Stubs
+
+None. The tool delegates directly to the fully-wired `CompareService` (Plan 03) over
+the live read-only SQLite connection; no placeholder data or mock wiring.
+
+## Notes for Downstream Plans
+
+- **Plan 05** can document the now-live `compare_versions` tool in README and add the
+  manual `.github/INTEGRATION-TEST.md` entry. The server exposes six tools; restart any
+  MCP client (Claude Desktop, Cursor, Inspector) to pick up the new tool.
+
+## Self-Check: PASSED
+
+- FOUND: src/mcp_server_python_docs/app_context.py (contains `compare_service: CompareService`)
+- FOUND: src/mcp_server_python_docs/server.py (contains `def compare_versions(` and `app_ctx.compare_service.compare`)
+- FOUND: tests/test_services.py (contains `test_six_tools_registered`)
+- FOUND: commit 9f63623 (Task 1)
+- FOUND: commit 4ced01a (Task 2)
+- FOUND: commit 89e4a2d (Task 3)
+- FOUND: commit c15e328 (Task 4)
+- FOUND: commit 13fe752 (Task 6 deviation fix)
+- Task 5 intentionally has no commit (verification-only, no file changes).
+
+---
+*Phase: 09-compare-versions*
+*Completed: 2026-05-28*

--- a/.planning/phases/09-compare-versions/09-05-user-facing-docs-PLAN.md
+++ b/.planning/phases/09-compare-versions/09-05-user-facing-docs-PLAN.md
@@ -1,0 +1,254 @@
+---
+phase: 09-compare-versions
+plan: 05
+type: execute
+wave: 3
+depends_on:
+  - 09-04-mcp-tool-wiring
+files_modified:
+  - README.md
+  - .github/INTEGRATION-TEST.md
+autonomous: true
+requirements:
+  - CMPR-01
+must_haves:
+  truths:
+    - "`README.md` 'Tools' section lists six tools (currently lists five), with `compare_versions` as a new row."
+    - "`README.md` no longer says 'currently exposes five MCP tools' or 'five read-only MCP tools' — both prose mentions are updated to six."
+    - "`.github/INTEGRATION-TEST.md` Test 1 (MCP Inspector quick loop) tool-list checklist includes ALL six current tools, in this order: `search_docs`, `get_docs`, `lookup_package_docs`, `list_versions`, `detect_python_version`, `compare_versions`. Per cross-AI review L2 option (a), `lookup_package_docs` is added to the checklist as part of this edit — since we are touching the list, we close the pre-existing inconsistency rather than papering over it."
+    - "Test 1 includes one Inspector-callable verification step for `compare_versions`: `compare_versions(symbol=\"asyncio.TaskGroup\", v1=\"3.10\", v2=\"3.11\")` expecting `change=\"added\"` and `new_in=\"3.11\"`."
+    - "All updates honor `POSITIONING.md` — the locked positioning sentence and the three key phrases are not altered."
+    - "Issue #32 hygiene: `git log --oneline origin/main..HEAD | rg 'Closes|Fixes|Resolves #32'` returns ZERO matches before PR creation. The `Closes #32` keyword belongs in the PR BODY only (per the #35 incident retrospective). The plan executor must run this pre-PR check explicitly and surface zero matches in the SUMMARY before the PR is opened."
+  artifacts:
+    - path: "README.md"
+      provides: "User-facing tool list reflecting the six-tool surface"
+      contains: "compare_versions"
+    - path: ".github/INTEGRATION-TEST.md"
+      provides: "Manual MCP QA runbook entry for ALL six tools (compare_versions + lookup_package_docs gap closed)"
+      contains: "compare_versions"
+  key_links:
+    - from: "README.md (Tools section, line ~178-188)"
+      to: "src/mcp_server_python_docs/server.py::compare_versions"
+      via: "table row labelled `compare_versions`"
+      pattern: "\\| `compare_versions` \\|"
+    - from: ".github/INTEGRATION-TEST.md (Test 1)"
+      to: "the running MCP server"
+      via: "checklist entry under `Confirm the tool list includes:` and a follow-up `Call compare_versions ...` step"
+      pattern: "compare_versions"
+---
+
+<objective>
+Update the two user-facing surfaces that lag behind the new MCP tool: `README.md` (which still says "five" tools in two places, lines ~46 and ~180) and `.github/INTEGRATION-TEST.md` (which lists four of the current tools in Test 1's checklist without `compare_versions` and also without `lookup_package_docs`).
+
+Per cross-AI review L2: since we are editing the INTEGRATION-TEST.md tool list, we close BOTH gaps in one pass — adding `compare_versions` AND `lookup_package_docs` — rather than leaving a pre-existing inconsistency in place.
+
+Per cross-AI review issue-#32 hygiene: the plan executor runs `git log --oneline origin/main..HEAD | rg 'Closes|Fixes|Resolves #32'` as a pre-PR check and records zero matches in the SUMMARY before opening the PR. This prevents an accidental issue closure recurrence of the #35 incident.
+
+Purpose: Satisfy the AGENTS.md "Done Means" gate — "user-facing docs reflect the current behavior" — and complete CMPR-01 from the user's perspective (the tool isn't really shipped if nobody knows it exists).
+
+Output: Two file modifications, no source code touched. Final task runs the full quality gate one more time AND the issue-#32 hygiene grep to confirm Phase 09 is complete.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@AGENTS.md
+@.planning/POSITIONING.md
+@.planning/phases/09-compare-versions/09-CONTEXT.md
+@.planning/phases/09-compare-versions/09-REVIEWS.md
+@README.md
+@.github/INTEGRATION-TEST.md
+
+<interfaces>
+<!-- README hook points (current state, line numbers verified) -->
+
+README.md line 46 (in "What you get" section):
+> - five read-only MCP tools
+
+README.md line 180 (in "Tools" section):
+> The server currently exposes five MCP tools:
+
+README.md lines 182-188 (the Tools table):
+```
+| Tool | Description |
+|------|-------------|
+| `search_docs` | Search Python stdlib docs by query. ... |
+| `get_docs` | Retrieve a specific documentation page or section by slug and optional anchor. ... |
+| `lookup_package_docs` | Look up official PyPI package metadata ... |
+| `list_versions` | List all indexed Python versions with metadata. |
+| `detect_python_version` | Detect the user's local Python version ... |
+```
+
+.github/INTEGRATION-TEST.md lines 38-50 (Test 1 — MCP Inspector quick loop) — current state (the L2 finding: lookup_package_docs is absent):
+```
+- [ ] Connect successfully over stdio
+- [ ] Confirm the tool list includes:
+  - `search_docs`
+  - `get_docs`
+  - `list_versions`
+  - `detect_python_version`
+- [ ] Call `search_docs` with query `asyncio.TaskGroup`, ...
+- [ ] Call `get_docs` for the returned slug and anchor
+- [ ] Call `list_versions`
+- [ ] Call `detect_python_version`
+```
+
+POSITIONING.md (locked sentence — do NOT alter):
+> For AI coding agents writing Python, python-docs-mcp-server is the canonical Python stdlib oracle: exact symbols, exact sections, exact versions — offline, **always free, always MIT**, token-frugal.
+</interfaces>
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Update README.md Tools table and prose mentions of "five tools"</name>
+  <read_first>
+    - README.md lines 40-50 ("What you get" list — verify the "five" mention is on line ~46)
+    - README.md lines 175-200 (Tools section — full table)
+    - .planning/POSITIONING.md (locked sentence — for guardrail)
+    - .planning/phases/09-compare-versions/09-CONTEXT.md (CMPR-01 tool description)
+  </read_first>
+  <action>
+    Make three edits to `README.md`:
+
+    (1) Line ~46 in "What you get" — change `- five read-only MCP tools` to `- six read-only MCP tools`.
+
+    (2) Line ~180 — change `The server currently exposes five MCP tools:` to `The server currently exposes six MCP tools:`.
+
+    (3) Tools table — append one new row immediately after the `detect_python_version` row (currently the last row, ~line 188). New row:
+
+    `| `compare_versions` | Diff a Python stdlib symbol between two indexed versions. Returns `change=added|removed|changed|unchanged` with optional `new_in`, `changed_in`, `deprecated_in`, `signature_delta` (advisory heuristic), `see_also_added/removed`, `section_diff`, and `note` deltas. Token-frugal — emits only changed fields, not full content. |`
+
+    (Note: per cross-AI review M1, the field is `signature_delta` not `signature_change`; per M2 the row includes the new `note` field.)
+
+    Do NOT alter the hero sentence (line 5 — locked positioning per POSITIONING.md). Do NOT alter any other section. Do NOT update the v0.1.4 MCP Registry badge in the header — that badge tracks the registry's last-published version and is out of scope for this phase.
+
+    After editing, manually re-read the Tools section to confirm Markdown table syntax is intact (pipe alignment is not load-bearing for renderers, but a missing pipe will break the table).
+  </action>
+  <verify>
+    <automated>grep -c "^- six read-only MCP tools$" README.md | grep -q "^1$" && grep -c "^The server currently exposes six MCP tools:$" README.md | grep -q "^1$" && grep -c "^| \`compare_versions\` |" README.md | grep -q "^1$" && ! grep -q "five read-only MCP tools" README.md && ! grep -q "currently exposes five MCP tools" README.md && grep -q "signature_delta" README.md && ! grep -q "signature_change" README.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `README.md` contains exactly one line `- six read-only MCP tools` and zero lines `- five read-only MCP tools`.
+    - Source: `README.md` contains exactly one line `The server currently exposes six MCP tools:` and zero lines `The server currently exposes five MCP tools:`.
+    - Source: `README.md` Tools table contains a row starting `| \`compare_versions\` |`.
+    - Source: `README.md` contains `signature_delta` (M1 — the new advisory field name) and does NOT contain `signature_change` (the old name).
+    - Source: the locked positioning sentence on README.md line 5 is unchanged (verify by `grep -c "canonical Python stdlib oracle" README.md` returns at least 1).
+    - Behavior: rendering README.md in a markdown viewer shows a 6-row Tools table with `compare_versions` as the last row.
+  </acceptance_criteria>
+  <done>README accurately reflects the six-tool surface; prose and table are consistent; field names match Plan 02 (signature_delta + note).</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add compare_versions AND lookup_package_docs to INTEGRATION-TEST.md Test 1 (L2 fix)</name>
+  <read_first>
+    - .github/INTEGRATION-TEST.md lines 25-52 (Test 1 — MCP Inspector quick loop section)
+    - .planning/phases/09-compare-versions/09-CONTEXT.md (Success criterion 1 — `compare_versions("asyncio.TaskGroup", "3.10", "3.11")` is the canonical end-to-end smoke test)
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (L2 option (a) — close the pre-existing `lookup_package_docs` gap while we're here)
+  </read_first>
+  <action>
+    Modify `.github/INTEGRATION-TEST.md` Test 1 — "MCP Inspector quick loop" (the section starting around line 25). Make THREE edits (per cross-AI review L2 option (a) — close the pre-existing inconsistency too):
+
+    **(1) In the "Confirm the tool list includes:" checklist (currently lines 39-43), the existing list is:**
+    ```
+      - `search_docs`
+      - `get_docs`
+      - `list_versions`
+      - `detect_python_version`
+    ```
+
+    Replace with the complete six-tool list, in this order (matching `server.py` registration order):
+    ```
+      - `search_docs`
+      - `get_docs`
+      - `lookup_package_docs`
+      - `list_versions`
+      - `detect_python_version`
+      - `compare_versions`
+    ```
+
+    Per cross-AI review L2 option (a): we are adding BOTH `lookup_package_docs` (the pre-existing gap) AND `compare_versions` (the Phase 09 addition). The rationale: since this edit touches the checklist anyway, closing the pre-existing inconsistency costs one extra line and prevents a future "the list is supposed to be complete but isn't" reviewer-confusion incident.
+
+    **(2) After the existing `- [ ] Call \`detect_python_version\`` line (~line 49) and before the `- [ ] Observe no protocol corruption ...` line (~line 51), insert a new checklist item for compare_versions:**
+
+    `- [ ] Call \`compare_versions\` with \`symbol="asyncio.TaskGroup"\`, \`v1="3.10"\`, \`v2="3.11"\`` (newline) `  - Expected: result with \`change="added"\` and \`new_in="3.11"\`, JSON serialization under ~1200 bytes`
+
+    (Use the same two-space indent for the Expected sub-bullet as the rest of Test 1.)
+
+    **(3) Optional consistency edit — do NOT add a `lookup_package_docs` Call step:**
+
+    Adding the tool to the enumeration list (Edit 1) is enough to close the L2 gap. Adding a Call step would expand scope beyond Phase 09. Document in the SUMMARY: "L2 closure adds `lookup_package_docs` to the enumeration list only; the Call-step for it is deferred to a future cleanup."
+
+    Do NOT add a separate top-level test section for compare_versions — keep it inline in Test 1. The other tests (Test 2 Claude Desktop, Test 3 Cursor, Test 4 Fresh install, Test 5 Slow E2E) do NOT need updates — they ask domain-style questions of the model rather than enumerating tools by name.
+  </action>
+  <verify>
+    <automated>grep -c "  - \`compare_versions\`" .github/INTEGRATION-TEST.md | grep -q "^1$" && grep -c "  - \`lookup_package_docs\`" .github/INTEGRATION-TEST.md | grep -q "^1$" && grep -c "Call \`compare_versions\` with" .github/INTEGRATION-TEST.md | grep -q "^1$" && grep -c "change=\"added\".*new_in=\"3.11\"" .github/INTEGRATION-TEST.md | grep -q "^1$"</automated>
+  </verify>
+  <acceptance_criteria>
+    - Source: `.github/INTEGRATION-TEST.md` Test 1 checklist contains a sub-bullet `  - \`compare_versions\`` exactly once.
+    - Source: `.github/INTEGRATION-TEST.md` Test 1 checklist contains a sub-bullet `  - \`lookup_package_docs\`` exactly once (L2 fix).
+    - Source: `.github/INTEGRATION-TEST.md` contains a checklist item starting `- [ ] Call \`compare_versions\` with` exactly once.
+    - Source: that checklist item includes `change="added"` and `new_in="3.11"` in its Expected line.
+    - Behavior: an operator following Test 1 can verify ALL SIX TOOLS are enumerated by the MCP server before any release (gap-closed checklist).
+  </acceptance_criteria>
+  <done>The manual MCP QA runbook teaches an operator how to verify the new tool over the stdio protocol, AND the pre-existing `lookup_package_docs` omission is closed (L2).</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Final phase quality gate + issue-#32 hygiene check</name>
+  <read_first>
+    - AGENTS.md "Done Means" lines 67-73 — the four required-clean gates
+    - .planning/phases/09-compare-versions/09-REVIEWS.md (issue-#32 hygiene paragraph — pre-PR keyword check)
+  </read_first>
+  <action>
+    Run the full AGENTS.md "Done Means" gate one last time, plus an end-to-end import smoke check that confirms the package builds cleanly with all Phase 09 additions and the new tool is enumerable. Then run the issue-#32 hygiene check.
+
+    **Issue-#32 hygiene check (per cross-AI review):** before opening the PR that closes #32, verify that NO intermediate commit message contains the GitHub closing keywords for issue #32. The keywords `Closes`, `Fixes`, and `Resolves` followed by `#32` ANYWHERE in the commit message body will auto-close the issue at merge time even if the PR is reverted later — and the #35 incident retrospective established that the closing keyword belongs in the PR body only, not in intermediate commits. The check:
+
+    ```
+    git log --oneline origin/main..HEAD | rg 'Closes|Fixes|Resolves #32'
+    ```
+
+    The expected result is ZERO output lines (i.e. `rg` exits 1 because nothing matched). Record the exact command and its output in the SUMMARY before PR creation. If any matches appear, do NOT open the PR — work with the user to rewrite the offending commit message(s) (e.g. via `git commit --amend` for the most recent, or `git rebase -i` for older — but only if the user explicitly approves the rebase).
+
+    This is the final phase verification — if anything fails here, do NOT mark Phase 09 complete; record the failure in the SUMMARY and open a follow-up issue.
+  </action>
+  <verify>
+    <automated>uv run ruff check src/ tests/ && uv run pyright src/ && uv run pytest --tb=short -q && uv run python -c "import asyncio; from mcp_server_python_docs.server import create_server; mcp = create_server(); tools = asyncio.run(mcp.list_tools()); names = sorted(t.name for t in tools); assert 'compare_versions' in names, names; assert len(names) == 6, f'expected 6 tools, got {len(names)}: {names}'; print('Phase 09 tools registered:', names)" && (git log --oneline origin/main..HEAD | grep -E 'Closes|Fixes|Resolves' | grep -E '#32' | wc -l | tr -d ' ' | grep -q '^0$' || (echo 'ISSUE-32-HYGIENE-FAIL: closing keyword leaked into intermediate commit message; rewrite before PR' && exit 1))</automated>
+  </verify>
+  <acceptance_criteria>
+    - CLI: `uv run ruff check src/ tests/` exits 0.
+    - CLI: `uv run pyright src/` exits 0.
+    - CLI: `uv run pytest --tb=short -q` exits 0 (full suite, all tests including the new `tests/test_compare_versions.py` AND the updated `test_six_tools_registered`).
+    - Behavior: the in-process tool enumeration confirms exactly 6 registered tools including `compare_versions`.
+    - Behavior: the issue-#32 hygiene grep returns ZERO matches (no intermediate commit contains `Closes #32` / `Fixes #32` / `Resolves #32`).
+    - Source: README.md and `.github/INTEGRATION-TEST.md` both mention `compare_versions` (verify with `grep -l compare_versions README.md .github/INTEGRATION-TEST.md`).
+    - Source: SUMMARY records the issue-#32 hygiene check's exact command and zero-match outcome.
+  </acceptance_criteria>
+  <done>Every AGENTS.md "Done Means" gate is green, `compare_versions` is callable end-to-end, AND the issue-#32 hygiene grep confirms the PR body is the only place the `Closes #32` keyword will appear. Phase 09 is complete and ready for a PR that closes issue #32.</done>
+</task>
+
+</tasks>
+
+<verification>
+- README.md Tools table has six rows; the new row uses `signature_delta` (NOT `signature_change`) and mentions `note`.
+- README.md prose says "six" tools in both places.
+- INTEGRATION-TEST.md Test 1 enumerates ALL SIX tools including the previously-missing `lookup_package_docs` (L2 closed) and includes a Call-step for `compare_versions`.
+- POSITIONING.md locked sentence is unchanged.
+- Full repo quality gate green.
+- Issue-#32 hygiene grep returns zero matches before PR creation.
+</verification>
+
+<success_criteria>
+- An operator running the README "Tools" section can see the new tool without reading any commit history or planning docs.
+- An operator running INTEGRATION-TEST.md Test 1 will catch a regression of `compare_versions` registration AND of any of the other five tools (the checklist is now complete).
+- The PR closing issue #32 includes the file changes from Plans 02-05 plus the SUMMARY files from each plan.
+- The PR body uses `Closes #32` exactly once. Intermediate commit messages do NOT include `Closes`/`Fixes`/`Resolves #32` — verified by the Task 3 hygiene grep (per the #35 incident retrospective).
+</success_criteria>
+
+<output>
+Create `.planning/phases/09-compare-versions/09-05-user-facing-docs-SUMMARY.md` when done.
+</output>

--- a/.planning/phases/09-compare-versions/09-05-user-facing-docs-SUMMARY.md
+++ b/.planning/phases/09-compare-versions/09-05-user-facing-docs-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: 09-compare-versions
+plan: 05
+subsystem: docs
+tags: [docs, readme, integration-test, compare_versions, cmpr-01]
+requires:
+  - 09-04-mcp-tool-wiring (compare_versions registered, six-tool surface live)
+provides:
+  - User-facing tool list reflecting the six-tool surface (README.md)
+  - Manual MCP QA runbook entry for all six tools (INTEGRATION-TEST.md)
+affects:
+  - README.md
+  - .github/INTEGRATION-TEST.md
+tech-stack:
+  added: []
+  patterns:
+    - Markdown table row mirrors server.py docstring field names verbatim (signature_delta, note)
+key-files:
+  created:
+    - .planning/phases/09-compare-versions/09-05-user-facing-docs-SUMMARY.md
+  modified:
+    - README.md
+    - .github/INTEGRATION-TEST.md
+decisions:
+  - "L2 closure: added lookup_package_docs to the INTEGRATION-TEST Test 1 enumeration list (not just compare_versions), closing the pre-existing four-tool gap in one pass."
+  - "lookup_package_docs Call-step deferred to a future cleanup; only the enumeration entry was added (scope discipline per L2 option (a))."
+  - "MCP Registry v0.1.4 badge left unchanged — it tracks the registry's last-published version and is out of scope for Phase 09."
+metrics:
+  duration: ~4 minutes
+  completed: 2026-05-28
+  tasks: 3
+  files: 2
+---
+
+# Phase 09 Plan 05: User-Facing Docs Summary
+
+Updated README.md and the INTEGRATION-TEST.md manual QA runbook to reflect the now-live six-tool MCP surface, adding `compare_versions` everywhere and closing the pre-existing `lookup_package_docs` enumeration gap (L2). Source code was not touched.
+
+## What Was Done
+
+### Task 1 — README.md six-tool surface (commit 7f90eda)
+- Changed `- five read-only MCP tools` to `- six read-only MCP tools` in "What you get".
+- Changed `The server currently exposes five MCP tools:` to `... six MCP tools:` in the Tools section.
+- Appended a `compare_versions` row to the Tools table after `detect_python_version`. The row uses the corrected field names per cross-AI review: `signature_delta` (M1, not `signature_change`) and includes the `note` delta (M2). Field names mirror the `compare_versions` docstring in `server.py` verbatim.
+- Locked positioning hero sentence (line 5) and the v0.1.4 MCP Registry badge were left untouched.
+
+### Task 2 — INTEGRATION-TEST.md Test 1 (commit da6d4c2)
+- Replaced the four-tool enumeration checklist with the complete six-tool list in `server.py` registration order: `search_docs`, `get_docs`, `lookup_package_docs`, `list_versions`, `detect_python_version`, `compare_versions`.
+- Inserted a `compare_versions` Inspector Call-step after `detect_python_version`: `symbol="asyncio.TaskGroup"`, `v1="3.10"`, `v2="3.11"`, expecting `change="added"` and `new_in="3.11"`, JSON under ~1200 bytes.
+- L2 closure: `lookup_package_docs` was added to the enumeration list only. The Call-step for it is deferred to a future cleanup to avoid expanding scope beyond Phase 09.
+
+### Task 3 — Final phase quality gate + issue-#32 hygiene check
+Full AGENTS.md "Done Means" gate run fresh, all green:
+- `uv run ruff check src/ tests/` → All checks passed.
+- `uv run pyright src/` → 0 errors, 0 warnings, 0 informations.
+- `uv run pytest --tb=short -q` → 281 passed in 8.12s.
+- In-process enumeration → `['compare_versions', 'detect_python_version', 'get_docs', 'list_versions', 'lookup_package_docs', 'search_docs']` (exactly 6, includes `compare_versions`).
+- Both docs mention `compare_versions` (`grep -l compare_versions README.md .github/INTEGRATION-TEST.md` lists both).
+
+#### Issue-#32 hygiene check (per cross-AI review / #35 incident retrospective)
+Command run:
+```
+git log --oneline origin/main..HEAD | grep -E 'Closes|Fixes|Resolves' | grep -E '#32'
+```
+Output: (empty — zero lines)
+Match count: `0`
+
+No intermediate commit on this branch contains `Closes #32` / `Fixes #32` / `Resolves #32`. The `Closes #32` keyword belongs in the PR body only; it is safe to open the PR that closes issue #32.
+
+## Deviations from Plan
+
+None — plan executed exactly as written. No Rule 1-4 deviations and no authentication gates encountered.
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| README says "six" tools in both prose sites | PASS |
+| README Tools table has `compare_versions` row with `signature_delta` + `note`, no `signature_change` | PASS |
+| Positioning hero sentence unchanged (`canonical Python stdlib oracle` present) | PASS |
+| INTEGRATION-TEST Test 1 enumerates all six tools incl. `lookup_package_docs` (L2) | PASS |
+| INTEGRATION-TEST has `compare_versions` Call-step with `change="added"` / `new_in="3.11"` | PASS |
+| ruff / pyright / pytest (281) all green | PASS |
+| In-process enumeration = exactly 6 tools | PASS |
+| Issue-#32 hygiene grep = zero matches | PASS |
+
+## Known Stubs
+
+None. Both files are user-facing documentation wired to the live tool surface; no placeholder data.
+
+## Self-Check: PASSED
+- FOUND: README.md (modified, compare_versions present)
+- FOUND: .github/INTEGRATION-TEST.md (modified, compare_versions present)
+- FOUND: commit 7f90eda (Task 1)
+- FOUND: commit da6d4c2 (Task 2)

--- a/.planning/phases/09-compare-versions/09-REVIEW.md
+++ b/.planning/phases/09-compare-versions/09-REVIEW.md
@@ -1,0 +1,227 @@
+---
+phase: 09-compare-versions
+reviewed: 2026-05-28T21:55:00Z
+depth: standard
+files_reviewed: 10
+files_reviewed_list:
+  - src/mcp_server_python_docs/models.py
+  - src/mcp_server_python_docs/services/compare.py
+  - src/mcp_server_python_docs/app_context.py
+  - src/mcp_server_python_docs/server.py
+  - tests/test_compare_versions.py
+  - tests/test_compare_versions_spike.py
+  - tests/test_retrieval_regression.py
+  - tests/test_services.py
+  - README.md
+  - .github/INTEGRATION-TEST.md
+findings:
+  critical: 1
+  warning: 4
+  info: 3
+  total: 8
+status: issues_found
+---
+
+# Phase 9: Code Review Report
+
+**Reviewed:** 2026-05-28T21:55:00Z
+**Depth:** standard
+**Files Reviewed:** 10
+**Status:** issues_found
+
+## Summary
+
+Phase 09 adds the `compare_versions` MCP tool: `CompareService.compare`, the
+`CompareVersionsResult` model, FastMCP wiring, behavioral tests, a spike script,
+and docs. The wiring, branch ordering (H2), and error delegation (H4) are sound,
+and the test suite is thorough for the seeded fixture.
+
+The dominant defect is a **slug-derivation mismatch** between `CompareService`
+and the rest of the retrieval stack. `compare.py` naively strips the symbol URI
+at `#` to get a `get_docs` slug, but the search path deliberately does NOT do
+this — it normalizes `.html` vs extensionless slugs through
+`ranker._resolve_symbol_location` / `_document_candidates`. Because real
+ingestion stores extensionless document slugs (`library/json`) while symbol URIs
+carry `.html` (`library/json.html`), `compare`'s section fetch will miss in
+production for typical stdlib symbols. The behavioral tests do not catch this
+because the test fixture stores `.html` slugs in `documents`, which does not
+mirror the production ingestion shape. Net effect in production: most
+`change="changed"`/both-present comparisons silently fall into the M2
+`PageNotFoundError` fallback — reporting `change="changed"` + a "docs page not
+available" note even for genuinely unchanged symbols, and never populating
+`changed_in` / `deprecated_in` / `signature_delta` / `see_also_*` / `section_diff`.
+This is a correctness regression that degrades the tool to "presence diff only"
+on real data while tests stay green.
+
+## Critical Issues
+
+### CR-01: compare's slug derivation bypasses the .html/extensionless slug normalization the rest of the stack relies on
+
+**File:** `src/mcp_server_python_docs/services/compare.py:130-139`
+**Issue:**
+`_section_text` derives the document slug with
+`slug = uri.split("#", 1)[0]` and passes it directly to
+`ContentService.get_docs(slug=slug, ...)`, which queries
+`documents WHERE slug = ?` (`content.py:73-77`). Symbol URIs come from
+`objects.inv` and use `.html` paths (e.g. `library/json.html#json.dumps`), but
+Sphinx JSON content is ingested with **extensionless** document slugs (e.g.
+`library/json`). This is exactly the mismatch that the search path handles
+deliberately via `ranker._document_candidates` (`ranker.py:24-34`) and
+`_resolve_symbol_location` (`ranker.py:37-103`), which try both the `.html` form
+and the stripped form and also fall back on `uri` matches. `compare.py`
+re-implements slug derivation but skips that normalization entirely.
+
+Consequences in production (real index):
+- both-present branch: `get_docs` raises `PageNotFoundError`, so the M2 fallback
+  at `compare.py:199-210` fires and returns `change="changed"` +
+  `note="docs page not available for one or both versions"` for **every**
+  both-present symbol — including symbols that did not actually change. All of
+  `changed_in`, `deprecated_in`, `signature_delta`, `see_also_*`, and
+  `section_diff` are never computed.
+- `added` branch: `new_in` extraction is silently swallowed
+  (`compare.py:179-183`), so `new_in` is always `None` for real "added" symbols.
+
+The behavioral tests pass only because `tests/test_compare_versions.py:136-140`
+inserts `documents` with `slug = slug` where `slug` is already the `.html` form
+(e.g. `library/asyncio-runner.html`), so the naive split happens to match. The
+fixture does not reproduce the production extensionless-slug shape documented for
+the real ingestion path, so the suite gives false confidence.
+
+**Fix:** Resolve the section via the same path the search stack uses instead of
+hand-rolling slug derivation. Two viable options:
+
+```python
+# Option A — resolve through the document candidates the ranker already uses.
+from mcp_server_python_docs.retrieval.ranker import _document_candidates
+
+def _section_text(self, uri: str, anchor: str, version: str) -> str:
+    for slug in _document_candidates(uri):
+        try:
+            return self._content.get_docs(
+                slug=slug, version=version, anchor=anchor
+            ).content
+        except PageNotFoundError:
+            continue
+    raise PageNotFoundError(f"no document for symbol uri {uri!r} v{version}")
+```
+
+Prefer promoting `_document_candidates` / `_resolve_symbol_location` to a shared,
+non-underscore helper so `compare` and `ranker` cannot drift. Additionally, add a
+behavioral test whose fixture stores **extensionless** document slugs (matching
+production ingestion) so this class of bug is caught by CI rather than masked.
+
+## Warnings
+
+### WR-01: see-also link extraction captures unrelated body links within the 20-line window
+
+**File:** `src/mcp_server_python_docs/services/compare.py:77-99`
+**Issue:**
+`_extract_see_also` locates the first line containing "see also", then matches
+**every** markdown link (`_SEE_ALSO_LINK_RE = r"\[([^\]]+)\]\("`) in the next 20
+lines until an ATX (`#`) heading. In real markdownify output a Sphinx `seealso`
+admonition is rendered as prose, not as an ATX heading, so the window is bounded
+only by the 20-line cap. Any ordinary inline links that follow the see-also block
+(cross-reference links, footnote links, body links) within those 20 lines are
+captured as "see also" labels, polluting `see_also_added` / `see_also_removed`
+with false positives. The model docstring itself warns the window must be honored
+"not against the whole section," but the line cap is too coarse to enforce that.
+**Fix:** Tighten the window: stop at the first blank line after the last
+consecutive link-bearing line, or restrict capture to lines that *start* with a
+list/link marker, rather than scanning a fixed 20-line block. At minimum,
+document that captured labels are best-effort and may include adjacent body
+links.
+
+### WR-02: section_diff is truncated by raw character slice, producing a corrupted/misleading diff
+
+**File:** `src/mcp_server_python_docs/services/compare.py:240-242`
+**Issue:**
+When the unified diff exceeds `_SECTION_DIFF_MAX_CHARS` (600), it is truncated
+with `section_diff = section_diff[:600]`. This cuts mid-line, so the final diff
+line is partial and may drop the trailing `+`/`-` context or split a hunk header,
+yielding output that no longer parses as a unified diff and can mislead a model
+consuming it. There is also no truncation marker, so the consumer cannot tell the
+diff was cut. **Fix:** Truncate on a line boundary and append an explicit marker,
+e.g.:
+
+```python
+if section_diff is not None and len(section_diff) > _SECTION_DIFF_MAX_CHARS:
+    kept = section_diff[:_SECTION_DIFF_MAX_CHARS].rsplit("\n", 1)[0]
+    section_diff = kept + "\n... (diff truncated)"
+```
+
+### WR-03: removed_in is set to v2 unconditionally, which can be factually wrong
+
+**File:** `src/mcp_server_python_docs/services/compare.py:188-192`
+**Issue:**
+The `removed` branch sets `removed_in=v2`. But the symbol may have been removed
+in some version *between* v1 and v2 (e.g. comparing 3.9 -> 3.13 for a symbol
+dropped in 3.11 reports `removed_in="3.13"`). The model field is documented as
+"version where the symbol is first absent," so reporting v2 is not the first
+absent version and can mislead callers about *when* the removal happened. The
+model docstring acknowledges `removed_in` "equals v2," but the
+`CompareVersionsResult.removed_in` description claims "first absent," which is
+contradictory. **Fix:** Either rename/redescribe the field to "absent as of v2"
+to match behavior, or compute the earliest indexed version (> v1, <= v2) in which
+the symbol is absent. At minimum, align the model description with the actual
+semantics to avoid a misleading contract.
+
+### WR-04: signature_delta heuristic emits noise for any prose change and is labeled "signature"
+
+**File:** `src/mcp_server_python_docs/services/compare.py:215-223`
+**Issue:**
+`signature_delta` compares only the first non-empty line of each section. When a
+section's first line is prose (not a signature) — common for class/module
+sections like `pathlib.Path` whose first line is descriptive text — a pure
+documentation/prose edit flips `signature_delta` to a non-`None` "line 1 differs"
+message that reads like a signature change. The test
+`test_compare_signature_delta_documents_prose_change` explicitly encodes this as
+"expected advisory behavior," but a field literally named `signature_delta`
+producing prose-diff noise is a quality/contract hazard for downstream models
+that will weight it as a signature change despite the docstring caveat.
+**Fix:** Gate the heuristic to lines that look like a signature (e.g. start with
+`def `, `class `, or contain `(`), or rename the field to `line1_delta` /
+`first_line_delta` to stop implying signature semantics. Keep the advisory note
+in the description regardless.
+
+## Info
+
+### IN-01: assert used for type narrowing will be stripped under python -O
+
+**File:** `src/mcp_server_python_docs/services/compare.py:195`
+**Issue:**
+`assert sym_v1 is not None and sym_v2 is not None` is used to narrow types for the
+checker. Under `python -O` (assertions disabled) this is a no-op; while the
+preceding branches make it logically unreachable when false, relying on `assert`
+for control-flow invariants is fragile. **Fix:** This one is purely a
+type-narrowing aid and the branch structure guarantees it, so it is low risk;
+optionally replace with an explicit guard or a `typing.cast` to avoid depending
+on assertions being enabled.
+
+### IN-02: compare.py imports sqlite3 only for a type annotation
+
+**File:** `src/mcp_server_python_docs/services/compare.py:27,120-128`
+**Issue:**
+`import sqlite3` is used solely for the `db: sqlite3.Connection` parameter
+annotation. With `from __future__ import annotations` in effect, the annotation
+is a string at runtime, so the import is only needed for static checking. This is
+consistent with the rest of the codebase (other services import it the same way),
+so it is not a defect — noting only for completeness. **Fix:** None required;
+leave as-is for consistency with sibling services.
+
+### IN-03: test_create_server_has_three_tools name is now misleading
+
+**File:** `tests/test_services.py:411-419`
+**Issue:**
+`test_create_server_has_three_tools` only asserts that `search_docs`, `get_docs`,
+and `list_versions` exist (a subset check), but the server now registers six
+tools and a sibling test `test_six_tools_registered` asserts the count. The
+"three tools" name is stale and can confuse future readers into thinking the
+server has three tools. **Fix:** Rename to
+`test_create_server_registers_core_tools` (or fold into the six-tool assertion)
+to reflect current reality.
+
+---
+
+_Reviewed: 2026-05-28T21:55:00Z_
+_Reviewer: Claude (gsd-code-reviewer)_
+_Depth: standard_

--- a/.planning/phases/09-compare-versions/09-REVIEW.md
+++ b/.planning/phases/09-compare-versions/09-REVIEW.md
@@ -19,8 +19,21 @@ findings:
   warning: 4
   info: 3
   total: 8
-status: issues_found
+status: resolved
+resolution:
+  fixed_in: 0e16b34
+  fixed: [CR-01, WR-01, WR-02]
+  accepted_by_design: [WR-03, WR-04]
+  info_noted: [IN-01, IN-02, IN-03]
 ---
+
+> **Resolution (commit 0e16b34):** CR-01 (blocker), WR-01, and WR-02 were fixed
+> inline with 3 added regression tests; the production-shaped fixture now stores
+> extensionless `documents.slug`. WR-03 (`removed_in=v2`) and WR-04
+> (`signature_delta` naming) are accepted as by-design — only two versions are
+> compared, so v2 *is* the first-absent version, and `signature_delta` was
+> already accepted as advisory (cross-AI M1). INFO items noted (IN-03 stale test
+> name is cosmetic). Full gate after fix: ruff clean, pyright 0 errors, 284 tests.
 
 # Phase 9: Code Review Report
 

--- a/.planning/phases/09-compare-versions/09-VERIFICATION.md
+++ b/.planning/phases/09-compare-versions/09-VERIFICATION.md
@@ -1,0 +1,120 @@
+---
+phase: 09-compare-versions
+verified: 2026-05-29T00:10:00Z
+status: passed
+score: 5/5 success criteria + all PLAN must_haves verified
+overrides_applied: 0
+re_verification: # not applicable — initial verification
+  previous_status: none
+gaps: []
+---
+
+# Phase 09: compare_versions(symbol, v1, v2) Verification Report
+
+**Phase Goal:** Ship the `compare_versions(symbol, v1, v2)` MCP tool — a new tool that diffs a Python stdlib symbol's documentation between two versions (GitHub issue #32).
+**Verified:** 2026-05-29T00:10:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths (CONTEXT.md success criteria — the contract)
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | `compare_versions("asyncio.TaskGroup", "3.10", "3.11")` returns a clear diff showing the symbol was newly introduced in 3.11 (`added`/`new_in` marker) | ✓ VERIFIED | `compare.py:202-213` added branch sets `change="added"` + extracts `new_in`. Test `test_compare_added_in_v2` asserts `change=="added"` and `new_in=="3.11"` — passing. |
+| 2 | Comparing identical versions returns an empty diff with explicit "no change" marker | ✓ VERIFIED | `compare.py:196-199` returns `change="unchanged"`. Test `test_compare_identical_versions` asserts unchanged + all delta fields None/empty — passing. |
+| 3 | Missing-version cases return an actionable error with the indexed-version list | ✓ VERIFIED | `compare.py:180-181` calls `validate_version` first; `version_resolution.py:29` raises `VersionNotFoundError` with available list (MVER-03). Test `test_compare_unknown_version_raises_with_indexed_list` asserts message names `3.99`, `3.10`, `3.11` — passing. |
+| 4 | Token cost of a typical diff is under 300 tokens | ✓ VERIFIED | `models.py` emits only non-None delta fields; `_SECTION_DIFF_MAX_CHARS=600`. Test `test_compare_diff_is_token_frugal` asserts `~tokens < 300` and serialized < 1200 bytes — passing (smoke check per L1). |
+| 5 | Integration test exercises 3 representative symbols (changed, unchanged, missing) | ✓ VERIFIED | `tests/test_compare_versions.py` covers added/removed/changed/unchanged + both error paths + heuristics + M2 fallback + CR-01/WR-01/WR-02 regressions (21 tests, all passing). |
+
+**Score:** 5/5 success criteria verified.
+
+### CMPR acceptance criteria (CONTEXT.md §Requirements)
+
+| Criterion | Status | Evidence |
+| --- | --- | --- |
+| CMPR-01: accepts `(symbol, v1, v2)`, returns structured diff (signature, docstring delta, deprecation flag, see-also +/-) | ✓ VERIFIED | `CompareService.compare` returns `CompareVersionsResult` with `signature_delta`, `section_diff`, `deprecated_in`, `see_also_added/removed`. Each has dedicated passing tests. |
+| CMPR-02: both versions must be indexed; else actionable error pointing at build-index | ✓ VERIFIED | `validate_version` raises `VersionNotFoundError` listing indexed versions before any symbol work. |
+| CMPR-03: JSON-serializable, token-frugal — no full re-printing of unchanged paragraphs | ✓ VERIFIED | Pydantic model `model_dump()`; section_diff truncated to 600 chars with line-boundary marker (WR-02); unchanged-case returns no diff body. |
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `src/mcp_server_python_docs/services/compare.py` | CompareService + compare() | ✓ VERIFIED | 312 lines; 4 branches, fixed H2 ordering, CR-01/WR-01/WR-02 fixes present. Wired into app_context + server. |
+| `src/mcp_server_python_docs/models.py` | CompareVersionsResult model | ✓ VERIFIED | `class CompareVersionsResult(BaseModel)` with all delta fields + `note`, every field has `Field(description=...)`. `signature_delta` (not `signature_change`), advisory description present. |
+| `tests/test_compare_versions.py` | Behavioral tests, production-shaped fixture | ✓ VERIFIED | 21 tests passing. Fixture stores EXTENSIONLESS `documents.slug` (`doc_slug = slug[:-5]`, line 145) matching ingestion ground truth — false-confidence masking is resolved. |
+| `src/mcp_server_python_docs/app_context.py` | `compare_service` field | ✓ VERIFIED | `compare_service: CompareService` (line 29). |
+| `src/mcp_server_python_docs/server.py` | `compare_versions` tool + lifespan wiring | ✓ VERIFIED | `CompareService(db, content_svc)` (line 163), passed to AppContext (line 189), `@mcp.tool def compare_versions` (line 393) delegating to `app_ctx.compare_service.compare`. |
+| `tests/test_services.py` | 6-tool registration | ✓ VERIFIED | `test_six_tools_registered` asserts `len(tools) == 6` (line 450/455); schema test inspects `compare_versions` params (line 480-485). |
+| `README.md` | six-tool list + compare_versions row | ✓ VERIFIED | "six read-only MCP tools" (line 46), "exposes six MCP tools" (line 180), `compare_versions` table row (line 189). |
+| `.github/INTEGRATION-TEST.md` | all six tools + compare_versions call step | ✓ VERIFIED | Test 1 checklist lists all six tools incl `lookup_package_docs` (L2 gap closed) and a `compare_versions` call step (line 53). |
+| `09-01-data-shape-spike-SUMMARY.md` | Locked regex patterns | ✓ VERIFIED | `## Locked regex patterns` section; regexes match compare.py verbatim. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| compare.py | cache.create_symbol_cache | import + `self._resolve(symbol, version)` | ✓ WIRED | `create_symbol_cache` returns `Callable[[str,str], CachedSymbol|None]`; `CachedSymbol` has `.uri`/`.anchor`. |
+| compare.py | content.ContentService.get_docs | `self._content.get_docs(slug, version, anchor)` | ✓ WIRED | Called in `_section_text`; CR-01 candidate logic present. |
+| compare.py | version_resolution.validate_version | import + call | ✓ WIRED | Called first in compare(); raises VersionNotFoundError from its own module. |
+| compare.py | observability.log_tool_call | `@log_tool_call("compare_versions")` | ✓ WIRED | Decorator present on `compare` (line 168). |
+| compare.py | VersionNotFoundError | (must NOT import — H4) | ✓ VERIFIED | grep confirms NOT imported; ruff F401 clean. |
+| server.app_lifespan | CompareService | `CompareService(db, content_svc)` | ✓ WIRED | Line 163. |
+| server.create_server | AppContext.compare_service | `app_ctx.compare_service.compare(...)` | ✓ WIRED | Line 407. |
+| models.py | server.py | batch import incl CompareVersionsResult | ✓ WIRED | Line 30-37. |
+
+### Data-Flow Trace (Level 4 — CR-01 focus)
+
+| Concern | Finding | Status |
+| --- | --- | --- |
+| `documents.slug` shape (ingestion ground truth) | `sphinx_json.py:429` `slug = current_page_name` (EXTENSIONLESS); `:439` `doc_uri = f"{current_page_name}.html"`. Symbol URIs carry `.html`. | ✓ confirmed |
+| Test fixture slug shape | `test_compare_versions.py:145` `doc_slug = slug[:-5] if slug.endswith(".html")` → stores EXTENSIONLESS slug, mirroring production. Old `.html`-in-both shape that masked CR-01 is gone. | ✓ FLOWING |
+| compare `_section_text` resolution | `compare.py:153` tries `(page[:-5], page)` extensionless-first, mirroring `ranker._document_candidates`. Resolves real-index symbols instead of falling into M2 fallback. | ✓ FLOWING |
+| CR-01 regression guard | `test_section_text_resolves_extensionless_slug_cr01` resolves `library/json.html#json.dumps` against extensionless slug AND asserts end-to-end `some.old_func` yields `deprecated_in="3.11"`, `note is None` (real metadata, not page-unavailable note). Passing. | ✓ FLOWING |
+
+### Behavioral Spot-Checks
+
+| Behavior | Command | Result | Status |
+| --- | --- | --- | --- |
+| Runtime tool enumeration = 6 incl compare_versions | `create_server(); asyncio.run(mcp.list_tools())` | count=6, names include `compare_versions` | ✓ PASS |
+| Compare suite | `pytest tests/test_compare_versions.py tests/test_services.py::TestToolRegistration` | 21 passed | ✓ PASS |
+| Deprecation regex version-agnostic | `_extract_deprecated_in("...3.12...")` | returns `3.12` | ✓ PASS |
+| Full gate — ruff | `uv run ruff check src/ tests/` | All checks passed | ✓ PASS |
+| Full gate — pyright | `uv run pyright src/` | 0 errors, 0 warnings | ✓ PASS |
+| Full gate — pytest | `uv run pytest --tb=short -q` | 284 passed in 8.13s | ✓ PASS |
+
+### Code Review Resolution Cross-Check (09-REVIEW.md, commit 0e16b34)
+
+| Finding | Claimed Fix | Codebase Evidence | Status |
+| --- | --- | --- | --- |
+| CR-01 (blocker): slug-derivation mismatch | extensionless-first candidates + production-shaped fixture | `compare.py:153` + fixture `:145` + regression test | ✓ FIXED |
+| WR-01: see-also over-capture | blank-line-bounded window | `compare.py:97-108` + `test_extract_see_also_excludes_unrelated_body_links_wr01` | ✓ FIXED |
+| WR-02: mid-line diff truncation | line-boundary truncation + marker | `compare.py:267-284` + `test_section_diff_truncates_on_line_boundary_wr02` | ✓ FIXED |
+| WR-03/WR-04 | accepted by-design (2-version semantics; advisory naming) | model descriptions align | ✓ ACCEPTED |
+| IN-03: stale `test_create_server_has_three_tools` name | cosmetic, not fixed | name still stale at `test_services.py:411` (subset check, still correct) | ℹ️ INFO |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+| --- | --- | --- | --- | --- |
+| (none) | — | No TBD/FIXME/XXX/HACK/PLACEHOLDER/stub in compare.py, models.py, or test file | — | — |
+| test_services.py | 411 | Stale test name `test_create_server_has_three_tools` (asserts 4-tool subset) | ℹ️ Info | Cosmetic only (IN-03, accepted in review); assertions correct, six-tool count covered by sibling test. Not a blocker. |
+
+### Issue #32 Hygiene
+
+`git log --oneline origin/main..HEAD | grep -iE "Closes|Fixes|Resolves" | grep "#32"` → ZERO matches. Closing keyword reserved for PR body per #35 retrospective. ✓ Clean.
+
+### Human Verification Required
+
+None. All success criteria are programmatically verified via the seeded fixture and runtime tool enumeration. Optional: live-index end-to-end MCP Inspector run per INTEGRATION-TEST.md Test 1 — covered by the documented runbook and not required for goal achievement (the CR-01 fix + production-shaped fixture close the previously-masked real-index gap).
+
+### Gaps Summary
+
+No gaps. The phase goal is achieved: a functional `compare_versions(symbol, v1, v2)` MCP tool is registered as the sixth tool, wired through AppContext and the FastMCP lifespan, returning a JSON-serializable token-frugal `CompareVersionsResult` across all four diff branches. The previously-identified blocker (CR-01 slug mismatch that degraded the tool to presence-only on real indexes) is fixed and guarded by a regression test using a production-shaped extensionless-slug fixture — verified against ingestion ground truth in `sphinx_json.py`. All canonical gates pass (ruff clean, pyright 0 errors, 284 tests).
+
+---
+
+_Verified: 2026-05-29T00:10:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tools for lookup and section retrieval.
 - page and section retrieval with truncation and pagination
 - a local SQLite + FTS5 index; no runtime web scraping
 - results for each Python version you index
-- five read-only MCP tools
+- six read-only MCP tools
 
 ## Quick example
 
@@ -177,7 +177,7 @@ Contributor commands and validation steps live in
 
 ## Tools
 
-The server currently exposes five MCP tools:
+The server currently exposes six MCP tools:
 
 | Tool | Description |
 |------|-------------|
@@ -186,6 +186,7 @@ The server currently exposes five MCP tools:
 | `lookup_package_docs` | Look up official PyPI package metadata and return package-declared documentation/homepage/source URLs. This is a controlled PyPI metadata lookup, not generic web search. |
 | `list_versions` | List all indexed Python versions with metadata. |
 | `detect_python_version` | Detect the user's local Python version and report whether that version has been indexed. |
+| `compare_versions` | Diff a Python stdlib symbol between two indexed versions. Returns `change=added|removed|changed|unchanged` with optional `new_in`, `changed_in`, `deprecated_in`, `signature_delta` (advisory heuristic), `see_also_added/removed`, `section_diff`, and `note` deltas. Token-frugal — emits only changed fields, not full content. |
 
 ## Why not Context7 or generic docs retrieval?
 

--- a/src/mcp_server_python_docs/app_context.py
+++ b/src/mcp_server_python_docs/app_context.py
@@ -10,6 +10,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from mcp_server_python_docs.services.compare import CompareService
 from mcp_server_python_docs.services.content import ContentService
 from mcp_server_python_docs.services.package_docs import PackageDocsService
 from mcp_server_python_docs.services.persistent_cache import PersistentDocsCache
@@ -25,6 +26,7 @@ class AppContext:
     index_path: Path
     search_service: SearchService
     content_service: ContentService
+    compare_service: CompareService
     version_service: VersionService
     package_docs_service: PackageDocsService = field(default_factory=PackageDocsService)
     persistent_docs_cache: PersistentDocsCache | None = None

--- a/src/mcp_server_python_docs/models.py
+++ b/src/mcp_server_python_docs/models.py
@@ -214,3 +214,90 @@ class PackageDocsResult(BaseModel):
         default=None,
         description="Controlled-scope note, for example skipped labels or not-found details",
     )
+
+
+# --- compare_versions models ---
+
+ChangeKind = Literal["added", "removed", "changed", "unchanged"]
+
+
+class CompareVersionsResult(BaseModel):
+    """Output from compare_versions tool (CMPR-01, CMPR-03).
+
+    Typed contract returned by CompareService.compare and the source FastMCP
+    auto-derives the compare_versions outputSchema from. The four ``change``
+    cases (added / removed / changed / unchanged) all share this shape;
+    optional delta fields are ``None`` when they do not apply to the case,
+    keeping the JSON shape predictable and token-frugal (no full re-printing
+    of unchanged content, per CMPR-03).
+    """
+
+    symbol: str = Field(description="Qualified symbol name being compared")
+    v1: str = Field(description="Source Python version")
+    v2: str = Field(description="Target Python version")
+    change: ChangeKind = Field(
+        description=(
+            "Diff discriminator: 'added' (symbol new in v2), 'removed' "
+            "(symbol absent in v2), 'changed' (symbol present in both with a "
+            "detected delta), or 'unchanged' (symbol present in both, no delta)"
+        )
+    )
+
+    new_in: str | None = Field(
+        default=None,
+        description=(
+            "Version string extracted from the v2 section text; populated when "
+            "change == 'added', and may also be set when change == 'changed' if "
+            "the v2 section carries a versionadded marker for a sub-feature"
+        ),
+    )
+    removed_in: str | None = Field(
+        default=None,
+        description=(
+            "Version where the symbol is first absent; populated when "
+            "change == 'removed' (equals v2)"
+        ),
+    )
+    changed_in: str | None = Field(
+        default=None,
+        description=(
+            "Version extracted from the v2 section; populated when "
+            "change == 'changed'"
+        ),
+    )
+    deprecated_in: str | None = Field(
+        default=None,
+        description="Version extracted from a deprecation marker in the v2 section",
+    )
+    signature_delta: str | None = Field(
+        default=None,
+        description=(
+            "Best-effort heuristic: first non-empty diff line between v1 and v2 "
+            "section text. MAY be a docstring change or prose change rather than "
+            "a true signature change — treat as advisory, not authoritative."
+        ),
+    )
+    see_also_added: list[str] = Field(
+        default_factory=list,
+        description="See-also link labels present in v2 but not v1",
+    )
+    see_also_removed: list[str] = Field(
+        default_factory=list,
+        description="See-also link labels present in v1 but not v2",
+    )
+    section_diff: str | None = Field(
+        default=None,
+        description=(
+            "Short unified-diff snippet (difflib.unified_diff), truncated to "
+            "honor the token budget; populated only when change == 'changed' and "
+            "the diff is non-trivially short"
+        ),
+    )
+    note: str | None = Field(
+        default=None,
+        description=(
+            "Optional advisory note about result completeness, e.g. when docs "
+            "pages could not be fetched for one or both versions and the diff is "
+            "therefore based on symbol presence alone."
+        ),
+    )

--- a/src/mcp_server_python_docs/server.py
+++ b/src/mcp_server_python_docs/server.py
@@ -28,6 +28,7 @@ from mcp_server_python_docs.app_context import AppContext
 from mcp_server_python_docs.detection import detect_python_version, match_to_indexed
 from mcp_server_python_docs.errors import DocsServerError
 from mcp_server_python_docs.models import (
+    CompareVersionsResult,
     DetectPythonVersionResult,
     GetDocsResult,
     ListVersionsResult,
@@ -271,6 +272,18 @@ PackageParam = Annotated[
     str,
     Field(min_length=1, max_length=214, description="PyPI package/project name"),
 ]
+SymbolParam = Annotated[
+    str,
+    Field(
+        min_length=1,
+        max_length=200,
+        description="Qualified Python symbol name, e.g. 'asyncio.TaskGroup'",
+    ),
+]
+CompareVersionParam = Annotated[
+    str,
+    Field(description="Python version string, e.g. '3.11'"),
+]
 
 
 def create_server() -> FastMCP:
@@ -376,6 +389,27 @@ def create_server() -> FastMCP:
             matched_index_version=detected_ver,
             is_default=detected_ver is not None,
         )
+
+    @mcp.tool(annotations=_TOOL_ANNOTATIONS)
+    def compare_versions(
+        symbol: SymbolParam,
+        v1: CompareVersionParam,
+        v2: CompareVersionParam,
+        ctx: Context = None,  # type: ignore[assignment]
+    ) -> CompareVersionsResult:
+        """Diff a Python stdlib symbol between two indexed versions. Returns
+        change=added|removed|changed|unchanged with optional new_in, changed_in,
+        deprecated_in, signature_delta (advisory), see_also_added/removed,
+        section_diff, and note fields. Both versions must be indexed; otherwise
+        an actionable error names the available versions."""
+        app_ctx: AppContext = ctx.request_context.lifespan_context
+        try:
+            return app_ctx.compare_service.compare(symbol, v1, v2)
+        except DocsServerError as e:
+            raise ToolError(str(e))
+        except Exception as e:
+            logger.exception("Unexpected error in compare_versions")
+            raise ToolError(f"Internal error: {type(e).__name__}")
 
     # SRVR-07: _meta hint for get_docs tool.
     # FastMCP 1.27 does not expose a public API for setting _meta on tool

--- a/src/mcp_server_python_docs/server.py
+++ b/src/mcp_server_python_docs/server.py
@@ -34,6 +34,7 @@ from mcp_server_python_docs.models import (
     PackageDocsResult,
     SearchDocsResult,
 )
+from mcp_server_python_docs.services.compare import CompareService
 from mcp_server_python_docs.services.content import ContentService
 from mcp_server_python_docs.services.package_docs import PackageDocsService
 from mcp_server_python_docs.services.persistent_cache import PersistentDocsCache
@@ -158,6 +159,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
         )
         search_svc = SearchService(db, synonyms)
         content_svc = ContentService(db, persistent_cache=persistent_docs_cache)
+        compare_svc = CompareService(db, content_svc)
         version_svc = VersionService(db)
         package_docs_svc = PackageDocsService()
 
@@ -183,6 +185,7 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
                 synonyms=synonyms,
                 search_service=search_svc,
                 content_service=content_svc,
+                compare_service=compare_svc,
                 version_service=version_svc,
                 package_docs_service=package_docs_svc,
                 persistent_docs_cache=persistent_docs_cache,

--- a/src/mcp_server_python_docs/services/compare.py
+++ b/src/mcp_server_python_docs/services/compare.py
@@ -90,11 +90,20 @@ def _extract_see_also(text: str) -> list[str]:
     if start is None:
         return []
 
+    # WR-01: a Sphinx "See also" admonition is one contiguous block. markdownify
+    # rarely emits an ATX heading after it, so an ATX-only break over-captures
+    # unrelated body links. Skip leading blanks, then read the block until the
+    # first blank line AFTER content has started (or an ATX heading, or the cap).
     window: list[str] = []
+    started = False
     for line in lines[start + 1 : start + 1 + 20]:
         if line.lstrip().startswith("#"):
             break
-        window.append(line)
+        if line.strip():
+            started = True
+            window.append(line)
+        elif started:
+            break  # blank line ends the admonition block
 
     return re.findall(_SEE_ALSO_LINK_RE, "\n".join(window))
 
@@ -132,11 +141,29 @@ class CompareService:
 
         Derives the slug from the symbol URI (everything before '#') and uses the
         symbol anchor — never joins symbols.section_id directly (RESEARCH Pitfall 2).
-        May raise PageNotFoundError if the page/section is not in the index.
+
+        CR-01: symbol URIs carry ".html" (``library/json.html#...``) but real
+        Sphinx ingestion stores ``documents.slug`` EXTENSIONLESS
+        (``library/json``), and ``get_docs`` matches ``documents.slug`` exactly.
+        Try the extensionless form first, then the raw ".html" page, mirroring
+        ``retrieval.ranker._document_candidates`` so resolution holds on a real
+        index. Raises PageNotFoundError only when every candidate misses.
         """
-        slug = uri.split("#", 1)[0]
-        result = self._content.get_docs(slug=slug, version=version, anchor=anchor)
-        return result.content
+        page = uri.split("#", 1)[0]
+        candidates = (page[:-5], page) if page.endswith(".html") else (page,)
+        last_exc: PageNotFoundError | None = None
+        for slug in candidates:
+            try:
+                result = self._content.get_docs(
+                    slug=slug, version=version, anchor=anchor
+                )
+            except PageNotFoundError as exc:
+                last_exc = exc
+                continue
+            return result.content
+        # candidates is non-empty, so last_exc is always set when we reach here.
+        assert last_exc is not None
+        raise last_exc
 
     @log_tool_call("compare_versions")
     def compare(self, symbol: str, v1: str, v2: str) -> CompareVersionsResult:
@@ -237,9 +264,24 @@ class CompareService:
                 n=2,
             )
         )
-        section_diff: str | None = "\n".join(diff_lines) if diff_lines else None
-        if section_diff is not None and len(section_diff) > _SECTION_DIFF_MAX_CHARS:
-            section_diff = section_diff[:_SECTION_DIFF_MAX_CHARS]
+        # WR-02: truncate on LINE boundaries (not mid-line) with an explicit
+        # marker, so the emitted diff stays a parseable unified diff.
+        section_diff: str | None = None
+        if diff_lines:
+            kept: list[str] = []
+            used = 0
+            truncated = False
+            for line in diff_lines:
+                projected = used + len(line) + (1 if kept else 0)
+                if projected > _SECTION_DIFF_MAX_CHARS:
+                    truncated = True
+                    break
+                kept.append(line)
+                used = projected
+            section_diff = "\n".join(kept)
+            if truncated:
+                marker = "... (diff truncated)"
+                section_diff = f"{section_diff}\n{marker}" if section_diff else marker
 
         # If nothing changed at all, the symbol is genuinely 'unchanged'.
         has_delta = (

--- a/src/mcp_server_python_docs/services/compare.py
+++ b/src/mcp_server_python_docs/services/compare.py
@@ -1,0 +1,269 @@
+"""Version-diff service for the compare_versions MCP tool (CMPR-01/02/03).
+
+Phase 09. Implements ``CompareService.compare(symbol, v1, v2)`` returning a
+``CompareVersionsResult``: the four diff branches (added / removed / changed /
+unchanged), the version/symbol error paths, and the see-also / deprecation /
+signature-delta heuristics.
+
+No structured signature/deprecation/see-also metadata is stored in the index,
+so this service derives those signals from section *text* using the regex
+literals locked by the Plan 09-01 data-shape spike, plus symbol presence/absence
+across the two doc_sets (via ``create_symbol_cache``).
+
+Algorithm ordering is FIXED per cross-AI review H2:
+  1. validate BOTH versions (validate_version raises the unknown-version error
+     from version_resolution; compare.py never names that exception type — H4)
+  2. resolve the symbol in BOTH versions
+  3. if missing in BOTH -> SymbolNotFoundError
+  4. ONLY THEN handle the v1 == v2 identical-versions case as 'unchanged'
+
+This ordering ensures ``compare('does.not.exist', '3.11', '3.11')`` raises
+SymbolNotFoundError rather than falsely returning 'unchanged'.
+"""
+from __future__ import annotations
+
+import difflib
+import re
+import sqlite3
+from typing import TYPE_CHECKING
+
+from mcp_server_python_docs.errors import PageNotFoundError, SymbolNotFoundError
+from mcp_server_python_docs.models import CompareVersionsResult
+from mcp_server_python_docs.services.cache import create_symbol_cache
+from mcp_server_python_docs.services.observability import log_tool_call
+from mcp_server_python_docs.services.version_resolution import validate_version
+
+if TYPE_CHECKING:
+    from mcp_server_python_docs.services.content import ContentService
+
+# --- Locked extractor regexes (verbatim from 09-01-data-shape-spike-SUMMARY) ---
+# All four HOLD against the spike fixture (A1/A2/sibling probes). Scalar
+# extractors return None on no-match; _extract_see_also returns [].
+_NEW_IN_RE = r"New in version\s+(\d+\.\d+)"
+_CHANGED_IN_RE = r"Changed in version\s+(\d+\.\d+)"
+_DEPRECATED_IN_RE = r"Deprecated since version\s+(\d+\.\d+)"
+# Markdown link label extractor; MUST be applied only within a "See also" window
+# (locate case-insensitive "see also", read forward to next ATX heading / window
+# end), not against the whole section, or it captures unrelated body links.
+_SEE_ALSO_LINK_RE = r"\[([^\]]+)\]\("
+
+# M2 note text emitted when a docs page is unfetchable in the both-present branch.
+_PAGE_UNAVAILABLE_NOTE = "docs page not available for one or both versions"
+
+# section_diff truncation ceiling (token-frugality, CMPR-03).
+_SECTION_DIFF_MAX_CHARS = 600
+# signature_delta heuristic: first-line snippet length cap.
+_SIGNATURE_LINE_MAX = 80
+
+
+def _extract_new_in(text: str) -> str | None:
+    """Extract the 'New in version X.Y' version, or None (locked _NEW_IN_RE)."""
+    match = re.search(_NEW_IN_RE, text)
+    return match.group(1) if match else None
+
+
+def _extract_changed_in(text: str) -> str | None:
+    """Extract the 'Changed in version X.Y' version, or None (_CHANGED_IN_RE)."""
+    match = re.search(_CHANGED_IN_RE, text)
+    return match.group(1) if match else None
+
+
+def _extract_deprecated_in(text: str) -> str | None:
+    """Extract the 'Deprecated since version X.Y' version, or None."""
+    match = re.search(_DEPRECATED_IN_RE, text)
+    return match.group(1) if match else None
+
+
+def _extract_see_also(text: str) -> list[str]:
+    """Extract see-also link labels from the 'See also' window only.
+
+    Locates the first case-insensitive 'see also' line, then reads forward to the
+    next ATX heading ('#') or up to 20 lines, and matches markdown link labels in
+    that window. Returns [] when there is no 'See also' section (fallback policy).
+    """
+    lines = text.splitlines()
+    start = None
+    for idx, line in enumerate(lines):
+        if "see also" in line.lower():
+            start = idx
+            break
+    if start is None:
+        return []
+
+    window: list[str] = []
+    for line in lines[start + 1 : start + 1 + 20]:
+        if line.lstrip().startswith("#"):
+            break
+        window.append(line)
+
+    return re.findall(_SEE_ALSO_LINK_RE, "\n".join(window))
+
+
+def _first_nonempty_line(text: str) -> str:
+    """Return the first non-blank line of a section text, or '' if none."""
+    for line in text.splitlines():
+        if line.strip():
+            return line.strip()
+    return ""
+
+
+class CompareService:
+    """Compute a structured version diff for a stdlib symbol (CMPR-01).
+
+    Composes existing primitives: ``validate_version`` (version existence +
+    actionable error), ``create_symbol_cache`` (version-scoped symbol
+    resolution), and ``ContentService.get_docs`` (section text retrieval).
+    The method is intentionally SYNC — SQLite reads on the open connection are
+    non-blocking; no asyncio.to_thread is used.
+    """
+
+    def __init__(
+        self,
+        db: sqlite3.Connection,
+        content_service: ContentService,
+    ) -> None:
+        self._db = db
+        self._content = content_service
+        # Private per-service LRU symbol resolver (own cache, RESEARCH §Q7).
+        self._resolve = create_symbol_cache(db)
+
+    def _section_text(self, uri: str, anchor: str, version: str) -> str:
+        """Fetch the section text for a symbol via ContentService.
+
+        Derives the slug from the symbol URI (everything before '#') and uses the
+        symbol anchor — never joins symbols.section_id directly (RESEARCH Pitfall 2).
+        May raise PageNotFoundError if the page/section is not in the index.
+        """
+        slug = uri.split("#", 1)[0]
+        result = self._content.get_docs(slug=slug, version=version, anchor=anchor)
+        return result.content
+
+    @log_tool_call("compare_versions")
+    def compare(self, symbol: str, v1: str, v2: str) -> CompareVersionsResult:
+        """Compare a symbol's documentation between two Python versions.
+
+        See module docstring for the FIXED branch ordering (H2). Returns one of
+        the four ``change`` cases; validate_version raises the unknown-version
+        error from its own module, or raises SymbolNotFoundError when the symbol
+        is absent in both versions.
+        """
+        # 1. Validate BOTH versions first. validate_version raises the
+        #    unknown-version error (with the indexed-version list) from its own
+        #    module — compare.py never references that exception type (H4).
+        validate_version(self._db, v1)
+        validate_version(self._db, v2)
+
+        # 2. Resolve the symbol in BOTH versions.
+        sym_v1 = self._resolve(symbol, v1)
+        sym_v2 = self._resolve(symbol, v2)
+
+        # 3. Missing in BOTH versions -> SymbolNotFoundError. This fires BEFORE
+        #    the v1 == v2 check so identical-versions with a non-existent symbol
+        #    raises rather than returning 'unchanged' (H2 fix).
+        if sym_v1 is None and sym_v2 is None:
+            raise SymbolNotFoundError(
+                f"symbol {symbol!r} not found in v{v1} or v{v2}"
+            )
+
+        # 4. Identical versions, symbol known to exist -> 'unchanged'.
+        if v1 == v2:
+            return CompareVersionsResult(
+                symbol=symbol, v1=v1, v2=v2, change="unchanged"
+            )
+
+        # 5. Branch on symbol presence across the two versions.
+        if sym_v1 is None and sym_v2 is not None:
+            # Added in v2. Best-effort new_in extraction; swallow
+            # PageNotFoundError (structural 'added' is sound without the section).
+            new_in: str | None = None
+            try:
+                text_v2 = self._section_text(sym_v2.uri, sym_v2.anchor, v2)
+                new_in = _extract_new_in(text_v2)
+            except PageNotFoundError:
+                new_in = None
+            return CompareVersionsResult(
+                symbol=symbol, v1=v1, v2=v2, change="added", new_in=new_in
+            )
+
+        if sym_v1 is not None and sym_v2 is None:
+            # Removed in v2 — no section fetch needed.
+            return CompareVersionsResult(
+                symbol=symbol, v1=v1, v2=v2, change="removed", removed_in=v2
+            )
+
+        # Both present. Narrow for the type checker.
+        assert sym_v1 is not None and sym_v2 is not None
+
+        # M2: if either section is unfetchable, report 'changed' + note rather
+        # than the previous false-negative 'unchanged'.
+        try:
+            text_v1 = self._section_text(sym_v1.uri, sym_v1.anchor, v1)
+            text_v2 = self._section_text(sym_v2.uri, sym_v2.anchor, v2)
+        except PageNotFoundError:
+            return CompareVersionsResult(
+                symbol=symbol,
+                v1=v1,
+                v2=v2,
+                change="changed",
+                section_diff=None,
+                note=_PAGE_UNAVAILABLE_NOTE,
+            )
+
+        changed_in = _extract_changed_in(text_v2)
+        deprecated_in = _extract_deprecated_in(text_v2)
+
+        # signature_delta (M1, advisory): first non-empty line comparison.
+        first_v1 = _first_nonempty_line(text_v1)
+        first_v2 = _first_nonempty_line(text_v2)
+        signature_delta: str | None = None
+        if first_v1 != first_v2:
+            signature_delta = (
+                f"line 1 differs (v{v1}: {first_v1[:_SIGNATURE_LINE_MAX]} "
+                f"-> v{v2}: {first_v2[:_SIGNATURE_LINE_MAX]})"
+            )
+
+        # See-also delta (set difference of link labels in each "See also" window).
+        see_v1 = set(_extract_see_also(text_v1))
+        see_v2 = set(_extract_see_also(text_v2))
+        see_also_added = sorted(see_v2 - see_v1)
+        see_also_removed = sorted(see_v1 - see_v2)
+
+        # Unified diff of the two section texts, truncated for token frugality.
+        diff_lines = list(
+            difflib.unified_diff(
+                text_v1.splitlines(),
+                text_v2.splitlines(),
+                lineterm="",
+                n=2,
+            )
+        )
+        section_diff: str | None = "\n".join(diff_lines) if diff_lines else None
+        if section_diff is not None and len(section_diff) > _SECTION_DIFF_MAX_CHARS:
+            section_diff = section_diff[:_SECTION_DIFF_MAX_CHARS]
+
+        # If nothing changed at all, the symbol is genuinely 'unchanged'.
+        has_delta = (
+            section_diff is not None
+            or changed_in is not None
+            or deprecated_in is not None
+            or signature_delta is not None
+            or bool(see_also_added)
+            or bool(see_also_removed)
+        )
+        if not has_delta:
+            return CompareVersionsResult(
+                symbol=symbol, v1=v1, v2=v2, change="unchanged"
+            )
+
+        return CompareVersionsResult(
+            symbol=symbol,
+            v1=v1,
+            v2=v2,
+            change="changed",
+            changed_in=changed_in,
+            deprecated_in=deprecated_in,
+            signature_delta=signature_delta,
+            see_also_added=see_also_added,
+            see_also_removed=see_also_removed,
+            section_diff=section_diff,
+        )

--- a/src/mcp_server_python_docs/services/compare.py
+++ b/src/mcp_server_python_docs/services/compare.py
@@ -39,13 +39,13 @@ if TYPE_CHECKING:
 # --- Locked extractor regexes (verbatim from 09-01-data-shape-spike-SUMMARY) ---
 # All four HOLD against the spike fixture (A1/A2/sibling probes). Scalar
 # extractors return None on no-match; _extract_see_also returns [].
-_NEW_IN_RE = r"New in version\s+(\d+\.\d+)"
-_CHANGED_IN_RE = r"Changed in version\s+(\d+\.\d+)"
-_DEPRECATED_IN_RE = r"Deprecated since version\s+(\d+\.\d+)"
+_NEW_IN_RE = re.compile(r"New in version\s+(\d+\.\d+)")
+_CHANGED_IN_RE = re.compile(r"Changed in version\s+(\d+\.\d+)")
+_DEPRECATED_IN_RE = re.compile(r"Deprecated since version\s+(\d+\.\d+)")
 # Markdown link label extractor; MUST be applied only within a "See also" window
 # (locate case-insensitive "see also", read forward to next ATX heading / window
 # end), not against the whole section, or it captures unrelated body links.
-_SEE_ALSO_LINK_RE = r"\[([^\]]+)\]\("
+_SEE_ALSO_LINK_RE = re.compile(r"\[([^\]]+)\]\(")
 
 # M2 note text emitted when a docs page is unfetchable in the both-present branch.
 _PAGE_UNAVAILABLE_NOTE = "docs page not available for one or both versions"
@@ -56,21 +56,13 @@ _SECTION_DIFF_MAX_CHARS = 600
 _SIGNATURE_LINE_MAX = 80
 
 
-def _extract_new_in(text: str) -> str | None:
-    """Extract the 'New in version X.Y' version, or None (locked _NEW_IN_RE)."""
-    match = re.search(_NEW_IN_RE, text)
-    return match.group(1) if match else None
+def _extract_version(pattern: re.Pattern[str], text: str) -> str | None:
+    """Return the captured version from the first match of ``pattern``, or None.
 
-
-def _extract_changed_in(text: str) -> str | None:
-    """Extract the 'Changed in version X.Y' version, or None (_CHANGED_IN_RE)."""
-    match = re.search(_CHANGED_IN_RE, text)
-    return match.group(1) if match else None
-
-
-def _extract_deprecated_in(text: str) -> str | None:
-    """Extract the 'Deprecated since version X.Y' version, or None."""
-    match = re.search(_DEPRECATED_IN_RE, text)
+    Shared by the New-in / Changed-in / Deprecated-since extractors, which differ
+    only by their (spike-locked) pattern literal (``_NEW_IN_RE`` etc.).
+    """
+    match = pattern.search(text)
     return match.group(1) if match else None
 
 
@@ -105,7 +97,7 @@ def _extract_see_also(text: str) -> list[str]:
         elif started:
             break  # blank line ends the admonition block
 
-    return re.findall(_SEE_ALSO_LINK_RE, "\n".join(window))
+    return _SEE_ALSO_LINK_RE.findall("\n".join(window))
 
 
 def _first_nonempty_line(text: str) -> str:
@@ -205,7 +197,7 @@ class CompareService:
             new_in: str | None = None
             try:
                 text_v2 = self._section_text(sym_v2.uri, sym_v2.anchor, v2)
-                new_in = _extract_new_in(text_v2)
+                new_in = _extract_version(_NEW_IN_RE, text_v2)
             except PageNotFoundError:
                 new_in = None
             return CompareVersionsResult(
@@ -236,8 +228,8 @@ class CompareService:
                 note=_PAGE_UNAVAILABLE_NOTE,
             )
 
-        changed_in = _extract_changed_in(text_v2)
-        deprecated_in = _extract_deprecated_in(text_v2)
+        changed_in = _extract_version(_CHANGED_IN_RE, text_v2)
+        deprecated_in = _extract_version(_DEPRECATED_IN_RE, text_v2)
 
         # signature_delta (M1, advisory): first non-empty line comparison.
         first_v1 = _first_nonempty_line(text_v1)

--- a/tests/test_compare_versions.py
+++ b/tests/test_compare_versions.py
@@ -1,0 +1,300 @@
+"""Behavioral tests for CompareService.compare (CMPR-01/02/03, Phase 09).
+
+Covers the four diff branches (added / removed / changed / unchanged), the
+version/symbol error paths, the see-also / deprecation / signature-delta
+heuristics, the M2 PageNotFoundError -> changed+note fallback, and the L1
+token-frugality smoke check.
+
+Each test maps to a cross-AI review finding (H2, H3, H4, M1, M2, M3, L1) and/or
+a CONTEXT.md success criterion. The exception types are imported from
+``..errors`` (NOT from compare.py), satisfying H4 option (a).
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mcp_server_python_docs.errors import SymbolNotFoundError, VersionNotFoundError
+from mcp_server_python_docs.services.compare import CompareService
+from mcp_server_python_docs.services.content import ContentService
+from mcp_server_python_docs.storage.db import bootstrap_schema, get_readwrite_connection
+
+# Section text fixtures (verbatim post-markdownify prose forms per 09-01 spike).
+_SECTIONS = {
+    # (version, anchor) -> (slug, content_text)
+    ("3.10", "asyncio.run"): (
+        "library/asyncio-runner.html",
+        "Execute the coroutine and return the result.\n\nMore prose.",
+    ),
+    ("3.11", "asyncio.run"): (
+        "library/asyncio-runner.html",
+        "def asyncio.run(coro, *, debug=None)\n\n"
+        "Execute the coroutine and return the result.\n\n"
+        "Changed in version 3.10: Improved behavior.",
+    ),
+    ("3.10", "json.dumps"): (
+        "library/json.html",
+        "Serialize obj to a JSON formatted str.",
+    ),
+    ("3.11", "json.dumps"): (
+        "library/json.html",
+        "Serialize obj to a JSON formatted str.",
+    ),
+    ("3.11", "asyncio.TaskGroup"): (
+        "library/asyncio-task.html",
+        "An asynchronous context manager holding a group of tasks.\n\n"
+        "New in version 3.11.",
+    ),
+    ("3.10", "pathlib.Path"): (
+        "library/pathlib.html",
+        "Concrete path classes.\n\nMore prose.",
+    ),
+    ("3.11", "pathlib.Path"): (
+        "library/pathlib.html",
+        "Concrete path classes.\n\nSee also\n\n"
+        "[os.path](library/os.path.html) — Operating system path manipulation.\n"
+        "[fnmatch](library/fnmatch.html) — Pattern matching.",
+    ),
+    ("3.10", "functools.cache"): (
+        "library/functools.html",
+        "Simple cache.\n\nSee also\n\n"
+        "[lru_cache](library/lru_cache.html) — LRU cache.",
+    ),
+    ("3.11", "functools.cache"): (
+        "library/functools.html",
+        "Simple cache.\n\nMore prose only, no see-also.",
+    ),
+    ("3.10", "some.old_func"): (
+        "library/somemodule.html",
+        "Old API.",
+    ),
+    ("3.11", "some.old_func"): (
+        "library/somemodule.html",
+        "Old API.\n\nDeprecated since version 3.11: use new_func() instead.",
+    ),
+    # Prose-only line-1 change variant for the M1 advisory-heuristic test.
+    ("3.10", "prose.thing"): (
+        "library/prose.html",
+        "Concrete path classes.\n\nBody.",
+    ),
+    ("3.11", "prose.thing"): (
+        "library/prose.html",
+        "Concrete pathy classes.\n\nBody.",
+    ),
+}
+
+# Symbols present per version. (version, qualified_name) -> (symbol_type, anchor)
+_SYMBOLS = {
+    ("3.10", "asyncio.run"): ("function", "asyncio.run"),
+    ("3.11", "asyncio.run"): ("function", "asyncio.run"),
+    ("3.10", "json.dumps"): ("function", "json.dumps"),
+    ("3.11", "json.dumps"): ("function", "json.dumps"),
+    ("3.11", "asyncio.TaskGroup"): ("class", "asyncio.TaskGroup"),
+    ("3.10", "pathlib.Path"): ("class", "pathlib.Path"),
+    ("3.11", "pathlib.Path"): ("class", "pathlib.Path"),
+    ("3.10", "functools.cache"): ("function", "functools.cache"),
+    ("3.11", "functools.cache"): ("function", "functools.cache"),
+    ("3.10", "some.old_func"): ("function", "some.old_func"),
+    ("3.11", "some.old_func"): ("function", "some.old_func"),
+    ("3.10", "prose.thing"): ("class", "prose.thing"),
+    ("3.11", "prose.thing"): ("class", "prose.thing"),
+}
+
+
+@pytest.fixture
+def compare_db(tmp_path):
+    """Two-version fixture (3.10 not-default, 3.11 default) for compare tests.
+
+    Local to this module (mirrors multi_version_db's inline placement). Seeds
+    doc_sets, documents, sections, and symbols so CompareService.compare can be
+    exercised end-to-end against real SQLite reads.
+    """
+    db_path = tmp_path / "compare.db"
+    conn = get_readwrite_connection(db_path)
+    bootstrap_schema(conn)
+
+    for ver, is_default in (("3.10", 0), ("3.11", 1)):
+        conn.execute(
+            "INSERT INTO doc_sets (source, version, language, label, is_default, base_url) "
+            "VALUES ('python-docs', ?, 'en', ?, ?, ?)",
+            (ver, f"Python {ver}", is_default, f"https://docs.python.org/{ver}/"),
+        )
+
+    ds_ids = {
+        row["version"]: row["id"]
+        for row in conn.execute("SELECT id, version FROM doc_sets").fetchall()
+    }
+
+    # Insert documents + sections. One document per (version, slug); one section
+    # per (version, anchor) keyed by the _SECTIONS table.
+    doc_ids: dict[tuple[str, str], int] = {}
+    for (ver, anchor), (slug, content) in _SECTIONS.items():
+        ds_id = ds_ids[ver]
+        key = (ver, slug)
+        if key not in doc_ids:
+            conn.execute(
+                "INSERT INTO documents (doc_set_id, uri, slug, title, content_text, char_count) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (ds_id, slug, slug, slug, "page", 4),
+            )
+            doc_ids[key] = conn.execute(
+                "SELECT id FROM documents WHERE doc_set_id = ? AND slug = ?",
+                (ds_id, slug),
+            ).fetchone()["id"]
+        doc_id = doc_ids[key]
+        uri = f"{slug}#{anchor}"
+        conn.execute(
+            "INSERT INTO sections "
+            "(document_id, uri, anchor, heading, level, ordinal, content_text, char_count) "
+            "VALUES (?, ?, ?, ?, 2, 0, ?, ?)",
+            (doc_id, uri, anchor, anchor, content, len(content)),
+        )
+
+    # Insert symbols.
+    for (ver, qname), (symbol_type, anchor) in _SYMBOLS.items():
+        ds_id = ds_ids[ver]
+        slug = _SECTIONS[(ver, anchor)][0]
+        uri = f"{slug}#{anchor}"
+        conn.execute(
+            "INSERT INTO symbols "
+            "(doc_set_id, qualified_name, normalized_name, module, symbol_type, uri, anchor) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (ds_id, qname, qname.lower(), qname.split(".")[0], symbol_type, uri, anchor),
+        )
+
+    conn.commit()
+    conn.execute("INSERT INTO symbols_fts(symbols_fts) VALUES('rebuild')")
+    conn.execute("INSERT INTO sections_fts(sections_fts) VALUES('rebuild')")
+    conn.commit()
+    yield conn
+    conn.close()
+
+
+def _service(db) -> CompareService:
+    """Build a CompareService wired to a ContentService over the same db."""
+    return CompareService(db, ContentService(db))
+
+
+def test_compare_added_in_v2(compare_db):
+    """CMPR-01 + success criterion #1: symbol new in v2 -> change='added'."""
+    result = _service(compare_db).compare("asyncio.TaskGroup", "3.10", "3.11")
+    assert result.change == "added"
+    assert result.symbol == "asyncio.TaskGroup"
+    assert result.v1 == "3.10"
+    assert result.v2 == "3.11"
+    assert result.new_in == "3.11"
+
+
+def test_compare_identical_versions(compare_db):
+    """Success criterion #2: identical versions (symbol exists) -> 'unchanged'."""
+    result = _service(compare_db).compare("json.dumps", "3.11", "3.11")
+    assert result.change == "unchanged"
+    assert result.new_in is None
+    assert result.section_diff is None
+    assert result.see_also_added == []
+    assert result.note is None
+
+
+def test_compare_changed_signature(compare_db):
+    """CMPR-01 changed branch + M1: line-1 signature reflected in signature_delta."""
+    result = _service(compare_db).compare("asyncio.run", "3.10", "3.11")
+    assert result.change == "changed"
+    assert result.changed_in == "3.10"
+    assert result.signature_delta is not None
+    # v2 line 1 is the function signature, so the heuristic includes it.
+    assert "def asyncio.run" in result.signature_delta
+
+
+def test_compare_signature_delta_documents_prose_change(compare_db):
+    """M1: heuristic is advisory — same line-1 -> None; differing prose -> non-None.
+
+    pathlib.Path's line 1 is identical across versions, so signature_delta is
+    None. prose.thing's line 1 differs in PROSE ONLY, yet the heuristic still
+    flags it: this is expected advisory behavior per M1 — production callers
+    should NOT trust signature_delta as a definitive signature-change indicator.
+    """
+    same = _service(compare_db).compare("pathlib.Path", "3.10", "3.11")
+    assert same.signature_delta is None
+
+    prose = _service(compare_db).compare("prose.thing", "3.10", "3.11")
+    assert prose.signature_delta is not None
+
+
+def test_compare_see_also_added(compare_db):
+    """CMPR-01 see-also + H3(a): gained references -> see_also_added populated."""
+    result = _service(compare_db).compare("pathlib.Path", "3.10", "3.11")
+    assert result.change == "changed"
+    assert "os.path" in result.see_also_added
+    assert "fnmatch" in result.see_also_added
+    assert result.see_also_removed == []
+
+
+def test_compare_see_also_removed(compare_db):
+    """CMPR-01 see-also + H3(b): lost references -> see_also_removed populated."""
+    result = _service(compare_db).compare("functools.cache", "3.10", "3.11")
+    assert result.change == "changed"
+    assert "lru_cache" in result.see_also_removed
+    assert result.see_also_added == []
+
+
+def test_compare_deprecated_in_v2(compare_db):
+    """CMPR-01 deprecation + H3(c): v2 deprecation marker -> deprecated_in set."""
+    result = _service(compare_db).compare("some.old_func", "3.10", "3.11")
+    assert result.change == "changed"
+    assert result.deprecated_in == "3.11"
+
+
+def test_compare_unknown_version_raises_with_indexed_list(compare_db):
+    """CMPR-02 + success criterion #3 + M3: error names the missing AND indexed versions."""
+    with pytest.raises(VersionNotFoundError) as exc_info:
+        _service(compare_db).compare("asyncio.run", "3.99", "3.11")
+    message = str(exc_info.value)
+    assert "3.99" in message  # the missing version is named
+    assert "3.10" in message  # at least one indexed version is named
+    assert "3.11" in message  # the other indexed version is also named
+
+
+def test_compare_identical_versions_missing_symbol_raises(compare_db):
+    """H2: identical versions must NOT short-circuit past symbol-existence check."""
+    with pytest.raises(SymbolNotFoundError, match="does.not.exist"):
+        _service(compare_db).compare("does.not.exist", "3.11", "3.11")
+
+
+def test_compare_neither_version_has_symbol(compare_db):
+    """RESEARCH §Q2(c) step 7: symbol absent in both versions -> SymbolNotFoundError."""
+    with pytest.raises(SymbolNotFoundError, match="does.not.exist"):
+        _service(compare_db).compare("does.not.exist", "3.10", "3.11")
+
+
+def test_compare_page_not_available_returns_changed_with_note(compare_db, monkeypatch):
+    """M2: PageNotFoundError in the both-present branch -> changed + note (not unchanged)."""
+    from mcp_server_python_docs.errors import PageNotFoundError
+
+    def _raise(*args, **kwargs):
+        raise PageNotFoundError("simulated page not found")
+
+    svc = _service(compare_db)
+    monkeypatch.setattr(svc._content, "get_docs", _raise)
+    # json.dumps exists in both 3.10 and 3.11, so we reach the both-present branch.
+    result = svc.compare("json.dumps", "3.10", "3.11")
+    assert result.change == "changed"
+    assert result.section_diff is None
+    assert result.note == "docs page not available for one or both versions"
+
+
+def test_compare_diff_is_token_frugal(compare_db):
+    """CMPR-03 + success criterion #4 + L1: byte-count regression smoke check.
+
+    This is a REGRESSION SMOKE CHECK, not a literal token guarantee. Production
+    tokenization may differ on unicode-heavy content; the assertion catches
+    'result accidentally got 3x bigger' regressions (per cross-AI review L1).
+    """
+    result = _service(compare_db).compare("asyncio.TaskGroup", "3.10", "3.11")
+    serialized = json.dumps(result.model_dump())
+    approx_tokens = len(serialized) // 4
+    assert approx_tokens < 300, (
+        f"diff serialized to {len(serialized)} bytes "
+        f"(~{approx_tokens} tokens), expected under 300"
+    )
+    assert len(serialized) < 1200

--- a/tests/test_compare_versions.py
+++ b/tests/test_compare_versions.py
@@ -15,8 +15,12 @@ import json
 
 import pytest
 
-from mcp_server_python_docs.errors import SymbolNotFoundError, VersionNotFoundError
-from mcp_server_python_docs.services.compare import CompareService
+from mcp_server_python_docs.errors import (
+    PageNotFoundError,
+    SymbolNotFoundError,
+    VersionNotFoundError,
+)
+from mcp_server_python_docs.services.compare import CompareService, _extract_see_also
 from mcp_server_python_docs.services.content import ContentService
 from mcp_server_python_docs.storage.db import bootstrap_schema, get_readwrite_connection
 
@@ -133,14 +137,20 @@ def compare_db(tmp_path):
         ds_id = ds_ids[ver]
         key = (ver, slug)
         if key not in doc_ids:
+            # Production-shaped slugs (CR-01 regression): real Sphinx ingestion
+            # stores documents.uri WITH ".html" but documents.slug EXTENSIONLESS
+            # (current_page_name); symbol/section URIs carry ".html". The old
+            # fixture seeded both columns with the ".html" form, masking the slug
+            # mismatch that broke get_docs on a real index.
+            doc_slug = slug[:-5] if slug.endswith(".html") else slug
             conn.execute(
                 "INSERT INTO documents (doc_set_id, uri, slug, title, content_text, char_count) "
                 "VALUES (?, ?, ?, ?, ?, ?)",
-                (ds_id, slug, slug, slug, "page", 4),
+                (ds_id, slug, doc_slug, slug, "page", 4),
             )
             doc_ids[key] = conn.execute(
                 "SELECT id FROM documents WHERE doc_set_id = ? AND slug = ?",
-                (ds_id, slug),
+                (ds_id, doc_slug),
             ).fetchone()["id"]
         doc_id = doc_ids[key]
         uri = f"{slug}#{anchor}"
@@ -269,7 +279,6 @@ def test_compare_neither_version_has_symbol(compare_db):
 
 def test_compare_page_not_available_returns_changed_with_note(compare_db, monkeypatch):
     """M2: PageNotFoundError in the both-present branch -> changed + note (not unchanged)."""
-    from mcp_server_python_docs.errors import PageNotFoundError
 
     def _raise(*args, **kwargs):
         raise PageNotFoundError("simulated page not found")
@@ -298,3 +307,74 @@ def test_compare_diff_is_token_frugal(compare_db):
         f"(~{approx_tokens} tokens), expected under 300"
     )
     assert len(serialized) < 1200
+
+
+# --- Code-review regression tests (CR-01, WR-01, WR-02) ---
+
+
+def test_section_text_resolves_extensionless_slug_cr01(compare_db):
+    """CR-01: symbol URIs carry '.html' but documents.slug is extensionless.
+
+    _section_text must resolve the '.html' symbol URI against the extensionless
+    documents.slug that real Sphinx ingestion stores. Before the fix this raised
+    PageNotFoundError on the production-shaped fixture, forcing every both-present
+    comparison into the M2 'page unavailable' fallback. Guards against regression
+    of the slug-derivation mismatch directly at the helper level.
+    """
+    svc = _service(compare_db)
+    text = svc._section_text("library/json.html#json.dumps", "json.dumps", "3.11")
+    assert "Serialize obj to a JSON formatted str." in text
+
+    # And end-to-end: the both-present 'changed' branch computes real metadata
+    # instead of returning the page-unavailable note.
+    result = svc.compare("some.old_func", "3.10", "3.11")
+    assert result.change == "changed"
+    assert result.deprecated_in == "3.11"
+    assert result.note is None
+
+
+def test_extract_see_also_excludes_unrelated_body_links_wr01():
+    """WR-01: the see-also window is one contiguous block.
+
+    A 'See also' admonition followed by a blank line and then unrelated body
+    prose (with its own links) must NOT capture those later links. markdownify
+    rarely emits an ATX heading after the admonition, so the blank-line boundary
+    is what bounds the window.
+    """
+    text = (
+        "Some intro paragraph.\n\n"
+        "See also\n"
+        "[json.tool](library/json.tool.html) — CLI helper.\n\n"
+        "This unrelated paragraph links to "
+        "[totally.unrelated](library/unrelated.html) and more.\n"
+    )
+    labels = _extract_see_also(text)
+    assert labels == ["json.tool"]
+    assert "totally.unrelated" not in labels
+
+
+def test_section_diff_truncates_on_line_boundary_wr02(compare_db, monkeypatch):
+    """WR-02: oversized section_diff truncates on a line boundary + marker.
+
+    The output must remain a parseable unified diff — no mid-line slice. Every
+    emitted line is a valid unified-diff line (' ', '+', '-', '@') or the
+    explicit truncation marker.
+    """
+    svc = _service(compare_db)
+
+    def _long_section(uri, anchor, version):
+        # Two large, fully-divergent bodies so the unified diff exceeds the cap.
+        marker = "alpha" if version == "3.10" else "omega"
+        return "\n".join(f"{marker} line {i} with content" for i in range(200))
+
+    monkeypatch.setattr(svc, "_section_text", _long_section)
+    result = svc.compare("json.dumps", "3.10", "3.11")
+
+    assert result.change == "changed"
+    assert result.section_diff is not None
+    assert len(result.section_diff) <= 600 + len("\n... (diff truncated)")
+    assert result.section_diff.endswith("... (diff truncated)")
+    for line in result.section_diff.splitlines():
+        if line == "... (diff truncated)":
+            continue
+        assert line[:1] in {" ", "+", "-", "@"}, f"corrupt diff line: {line!r}"

--- a/tests/test_compare_versions_spike.py
+++ b/tests/test_compare_versions_spike.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+"""Data-shape spike for Phase 09 compare_versions (Plan 09-01, CMPR-01).
+
+This is a standalone, re-runnable evidence builder — NOT a pytest module.
+Run it directly on a fresh checkout, offline, with no user-cache dependency:
+
+    uv run python tests/test_compare_versions_spike.py
+
+It builds a reproducible two-version SQLite fixture under a
+``tempfile.TemporaryDirectory()`` (mirroring the
+``tests/test_multi_version.py::multi_version_db`` pattern) and probes the
+candidate regexes that ``services/compare.py`` (Plan 03) will use to extract
+``new_in`` / ``changed_in`` / ``deprecated_in`` / ``see_also`` from
+``sections.content_text``.
+
+The seeded prose forms are the literal post-markdownify strings that
+RESEARCH §Q3(a) (lines 170-184) and §Q4(a) (lines 197-210) document as
+surviving the ``markdownify`` call in ``sphinx_json.py:247``. The spike's job
+is to LOCK the regex literals against this controlled fixture — not to
+rediscover what RESEARCH already proved.
+
+It never touches the user cache: it does not resolve the default index path,
+does not invoke the index-build CLI, and does not read or write the
+platformdirs cache directory. All data lives in the temp fixture only.
+Exits 0 and prints "spike fixture OK" plus per-probe results on success.
+"""
+from __future__ import annotations
+
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+from mcp_server_python_docs.storage.db import (
+    bootstrap_schema,
+    get_readwrite_connection,
+)
+
+# ── Candidate regex literals (from RESEARCH §Q3(a)-(c) and §Q4(c)) ──────────
+# These are the exact strings the spike locks for services/compare.py (Plan 03).
+NEW_IN_RE = r"New in version\s+(\d+\.\d+)"
+CHANGED_IN_RE = r"Changed in version\s+(\d+\.\d+)"
+DEPRECATED_IN_RE = r"Deprecated since version\s+(\d+\.\d+)"
+SEE_ALSO_LINK_RE = r"\[([^\]]+)\]\("
+
+# ── Seeded prose forms (verbatim, RESEARCH-documented post-markdownify text) ─
+# (slug, anchor, content_text)
+_SECTIONS_3_11 = [
+    (
+        "library/asyncio-task.html",
+        "asyncio.TaskGroup",
+        "An asynchronous context manager holding a group of tasks.\n\n"
+        "New in version 3.11.",
+    ),
+    (
+        "library/asyncio-runner.html",
+        "asyncio.run",
+        "Execute the coroutine and return the result.\n\n"
+        "Changed in version 3.10: Added support for ...",
+    ),
+    (
+        "library/somemodule.html",
+        "some.deprecated_func",
+        "Old API.\n\nDeprecated since version 3.12: use new_func() instead.",
+    ),
+    (
+        "library/pathlib.html",
+        "pathlib.Path",
+        "Concrete path classes.\n\nSee also\n\n"
+        "[os.path](library/os.path.html) — Operating system path manipulation.\n"
+        "[fnmatch](library/fnmatch.html) — Pattern matching.",
+    ),
+]
+
+
+def build_fixture(db_path: Path):
+    """Build the two-version SQLite fixture and return the open connection.
+
+    Mirrors tests/test_multi_version.py::multi_version_db:
+    - doc_set 3.10 (not default), doc_set 3.11 (default)
+    - documents + sections carrying the verbatim RESEARCH prose forms
+    - FTS rebuild for parity with the real ingestion path
+    """
+    conn = get_readwrite_connection(db_path)
+    bootstrap_schema(conn)
+
+    # 3.10 — not default (presence-delta baseline; carries no seeded directives)
+    conn.execute(
+        "INSERT INTO doc_sets (source, version, language, label, is_default, base_url) "
+        "VALUES ('python-docs', '3.10', 'en', 'Python 3.10', 0, "
+        "'https://docs.python.org/3.10/')"
+    )
+    # 3.11 — default; carries the four probed sections
+    conn.execute(
+        "INSERT INTO doc_sets (source, version, language, label, is_default, base_url) "
+        "VALUES ('python-docs', '3.11', 'en', 'Python 3.11', 1, "
+        "'https://docs.python.org/3.11/')"
+    )
+
+    ds_311 = conn.execute(
+        "SELECT id FROM doc_sets WHERE version = '3.11'"
+    ).fetchone()[0]
+
+    for slug, anchor, content_text in _SECTIONS_3_11:
+        conn.execute(
+            "INSERT INTO documents (doc_set_id, uri, slug, title, content_text, char_count) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (ds_311, slug, slug, anchor, content_text, len(content_text)),
+        )
+        doc_id = conn.execute(
+            "SELECT id FROM documents WHERE doc_set_id = ? AND slug = ?",
+            (ds_311, slug),
+        ).fetchone()[0]
+        uri = f"{slug}#{anchor}"
+        conn.execute(
+            "INSERT INTO sections "
+            "(document_id, uri, anchor, heading, level, ordinal, content_text, char_count) "
+            "VALUES (?, ?, ?, ?, 2, 0, ?, ?)",
+            (doc_id, uri, anchor, anchor, content_text, len(content_text)),
+        )
+
+    conn.commit()
+    conn.execute("INSERT INTO sections_fts(sections_fts) VALUES('rebuild')")
+    conn.commit()
+    return conn
+
+
+def _fetch_section(conn, anchor: str) -> str:
+    row = conn.execute(
+        "SELECT content_text FROM sections WHERE anchor = ?", (anchor,)
+    ).fetchone()
+    assert row is not None, f"section not seeded: {anchor}"
+    return row[0]
+
+
+def run_probes(conn) -> list[tuple[str, str, object, bool]]:
+    """Run each candidate regex against the seeded prose; return outcomes.
+
+    Each tuple: (probe_label, regex_literal, captured_value, holds_bool).
+    """
+    results: list[tuple[str, str, object, bool]] = []
+
+    # A1 — versionadded
+    text = _fetch_section(conn, "asyncio.TaskGroup")
+    m = re.search(NEW_IN_RE, text)
+    cap = m.group(1) if m else None
+    results.append(("A1 (versionadded)", NEW_IN_RE, cap, cap == "3.11"))
+
+    # Sibling 1 — changed
+    text = _fetch_section(conn, "asyncio.run")
+    m = re.search(CHANGED_IN_RE, text)
+    cap = m.group(1) if m else None
+    results.append(("Sibling 1 (changed)", CHANGED_IN_RE, cap, cap == "3.10"))
+
+    # Sibling 2 — deprecated
+    text = _fetch_section(conn, "some.deprecated_func")
+    m = re.search(DEPRECATED_IN_RE, text)
+    cap = m.group(1) if m else None
+    results.append(("Sibling 2 (deprecated)", DEPRECATED_IN_RE, cap, cap == "3.12"))
+
+    # A2 — seealso (link labels within the "See also" window)
+    text = _fetch_section(conn, "pathlib.Path")
+    idx = text.lower().find("see also")
+    window = text[idx:] if idx >= 0 else ""
+    cap = re.findall(SEE_ALSO_LINK_RE, window)
+    results.append(("A2 (seealso)", SEE_ALSO_LINK_RE, cap, cap == ["os.path", "fnmatch"]))
+
+    return results
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        db_path = Path(td) / "spike.db"
+        conn = build_fixture(db_path)
+        try:
+            print("spike fixture OK")
+            results = run_probes(conn)
+            all_hold = True
+            for label, regex, cap, holds in results:
+                status = "HOLDS" if holds else "FALSIFIED"
+                all_hold = all_hold and holds
+                print(f"  [{status}] {label}: {regex!r} -> {cap!r}")
+            if all_hold:
+                print("all 4 probes HOLD")
+                return 0
+            print("FAILURE: one or more probes FALSIFIED", file=sys.stderr)
+            return 1
+        finally:
+            conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_retrieval_regression.py
+++ b/tests/test_retrieval_regression.py
@@ -10,6 +10,7 @@ import pytest
 from mcp_server_python_docs.app_context import AppContext
 from mcp_server_python_docs.errors import VersionNotFoundError
 from mcp_server_python_docs.server import create_server
+from mcp_server_python_docs.services.compare import CompareService
 from mcp_server_python_docs.services.content import ContentService
 from mcp_server_python_docs.services.search import SearchService
 from mcp_server_python_docs.services.version import VersionService
@@ -122,11 +123,13 @@ def regression_db(tmp_path):
 
 def _make_app_context(db, detected_python_version: str | None) -> AppContext:
     """Build an AppContext for direct tool invocation tests."""
+    content_service = ContentService(db)
     return AppContext(
         db=db,
         index_path=Path("retrieval-regression.db"),
         search_service=SearchService(db, {}),
-        content_service=ContentService(db),
+        content_service=content_service,
+        compare_service=CompareService(db, content_service),
         version_service=VersionService(db),
         detected_python_version=detected_python_version,
         detected_python_source="test fixture",

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -433,7 +433,7 @@ class TestToolRegistration:
 
         server = create_server()
         tools = server._tool_manager._tools
-        for name in ["search_docs", "get_docs", "list_versions"]:
+        for name in ["search_docs", "get_docs", "list_versions", "compare_versions"]:
             tool = tools[name]
             annotations = tool.annotations
             assert annotations is not None, f"{name} missing annotations"
@@ -447,12 +447,12 @@ class TestToolRegistration:
                 annotations.openWorldHint is False
             ), f"{name} openWorldHint should be False"
 
-    def test_five_tools_registered(self):
+    def test_six_tools_registered(self):
         from mcp_server_python_docs.server import create_server
 
         server = create_server()
         tools = server._tool_manager._tools
-        assert len(tools) == 5
+        assert len(tools) == 6
 
     def test_runtime_tool_schemas_include_input_constraints(self):
         import anyio
@@ -476,6 +476,13 @@ class TestToolRegistration:
         assert get_docs["max_chars"]["minimum"] == 100
         assert get_docs["max_chars"]["maximum"] == 50000
         assert get_docs["start_index"]["minimum"] == 0
+
+        compare_versions = schemas["compare_versions"]["properties"]
+        assert compare_versions["symbol"]["maxLength"] == 200
+        assert compare_versions["symbol"]["minLength"] == 1
+        # v1 and v2 do not have min/max length constraints by current design.
+        assert "v1" in compare_versions
+        assert "v2" in compare_versions
 
     def test_app_lifespan_closes_db_on_pre_yield_error(self, tmp_path):
         import anyio

--- a/uv.lock
+++ b/uv.lock
@@ -234,11 +234,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -836,15 +836,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #32

## Summary

Adds the **`compare_versions(symbol, v1, v2)`** MCP tool — the 6th tool — which diffs a Python stdlib symbol's documentation between two versions and returns a structured `CompareVersionsResult` (one of `added` / `removed` / `changed` / `unchanged`).

Built in 4 waves across 5 plans:
- **Spike** — locked the four section-text extractor regexes (`New in` / `Changed in` / `Deprecated since` / see-also link) against a reproducible offline fixture.
- **Model** — `CompareVersionsResult` + `ChangeKind`, with `signature_delta` (advisory) and `note` fields; FastMCP auto-derives the tool's `outputSchema` from it.
- **Service** — `CompareService.compare` composing `validate_version` + version-scoped symbol resolution + `ContentService.get_docs`, with fixed branch ordering (validate → resolve → both-missing → identical).
- **Wiring** — `AppContext` field, lifespan construction, `@mcp.tool` registration, `SymbolParam`/`CompareVersionParam` aliases, and updated registration tests for the 6-tool surface.
- **Docs** — README and INTEGRATION-TEST updated to the six-tool surface.

## Code review caught a production blocker (fixed)

An auto-invoked review found that `compare_versions` was silently **non-functional on a real index**: `_section_text` derived the `get_docs` slug as `uri.split("#")[0]`, keeping the `.html` extension, but real Sphinx ingestion stores `documents.slug` *extensionless* (`get_docs` matches `documents.slug` exactly). The original tests passed only because the fixture stored `.html` in both columns — false confidence.

Fixed inline (TDD — the production-shaped fixture turned the bug RED across 6 tests, then GREEN):
- **CR-01** — extensionless-first slug candidates, mirroring `ranker._document_candidates`.
- **WR-01** — see-also window bounded to the contiguous admonition block (not greedy).
- **WR-02** — `section_diff` truncates on line boundaries with an explicit marker.
- WR-03 (`removed_in=v2`) and WR-04 (`signature_delta` naming) accepted as by-design.
- 3 dedicated regression tests added; an independent verifier re-confirmed the fix and the 6-tool runtime registration.

## Verification

- `uv run ruff check src/ tests/` — clean
- `uv run pyright src/` — 0 errors
- `uv run pytest` — **284 passed** (269 at phase start, +15)
- Runtime check: `create_server()` → `list_tools()` returns exactly 6 tools including `compare_versions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New compare_versions tool: compare a stdlib symbol across two indexed docs and get change classification (added/removed/changed/unchanged) plus optional signature delta, see‑also changes, deprecation markers, and a compact diff snippet.

* **Documentation**
  * README and integration-test runbook updated to list the six tools and include a compare_versions check step.

* **Tests**
  * Added comprehensive tests validating compare behavior, heuristics, and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->