### PR TITLE
fix(ingestion): serial Sphinx build on Python 3.14+ (forkserver pickling)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `python-docs-mcp-server` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`build-index` on Python 3.14** — Sphinx's parallel JSON build (`-j auto`)
+  raised `_pickle.PicklingError` on Python 3.14, which flipped the default
+  `multiprocessing` start method on POSIX from `fork` to `forkserver`
+  (`forkserver` must pickle worker tasks, but Sphinx's `ParallelTasks` holds an
+  unpicklable local closure). The builder now falls back to a serial build
+  (`-j 1`) on 3.14+ while keeping the parallel path on `fork`-default
+  interpreters (3.13 and earlier). Server runtime behavior is unchanged.
+
 ## [0.2.0] — 2026-05-29
 
 ### Added

--- a/src/mcp_server_python_docs/ingestion/sphinx_json.py
+++ b/src/mcp_server_python_docs/ingestion/sphinx_json.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import sqlite3
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -166,6 +167,25 @@ def make_sphinx_json_env(
     return env
 
 
+def sphinx_parallel_jobs(
+    version_info: tuple[int, ...] = (sys.version_info.major, sys.version_info.minor),
+) -> str:
+    """Return the Sphinx ``-j`` value for the build interpreter.
+
+    The Sphinx venv is created from the current interpreter (``venv.create``),
+    so ``sys.version_info`` reflects the Python that will run ``sphinx-build``.
+
+    Python 3.14 changed the default ``multiprocessing`` start method on
+    POSIX from ``fork`` to ``forkserver``. ``forkserver`` pickles the work
+    handed to child processes, but Sphinx's parallel build passes a
+    ``ParallelTasks`` object holding a local closure
+    (``Builder._read_parallel.<locals>.merge``) that cannot be pickled, so
+    ``-j auto`` raises ``_pickle.PicklingError`` on 3.14+. Fall back to a
+    serial build there; ``fork``-default interpreters keep the parallel path.
+    """
+    return "1" if version_info >= (3, 14) else "auto"
+
+
 def build_sphinx_json_command(
     sphinx_build: Path | str,
     doc_dir: Path | str,
@@ -179,7 +199,7 @@ def build_sphinx_json_command(
         "-D",
         "html_theme=classic",
         "-j",
-        "auto",
+        sphinx_parallel_jobs(),
         str(doc_dir),
         str(json_out),
     ]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -34,6 +34,7 @@ from mcp_server_python_docs.ingestion.sphinx_json import (
     parse_fjson,
     populate_synonyms,
     rebuild_fts_indexes,
+    sphinx_parallel_jobs,
     write_json_build_requirements,
     write_sphinx_json_sitecustomize,
 )
@@ -227,10 +228,21 @@ class TestSphinxJsonCommand:
             "-D",
             "html_theme=classic",
             "-j",
-            "auto",
+            sphinx_parallel_jobs(),
             str(doc_dir),
             str(json_out),
         ]
+
+    def test_sphinx_parallel_jobs_auto_before_314(self):
+        """Pre-3.14 interpreters keep the parallel 'auto' build (fork default)."""
+        assert sphinx_parallel_jobs((3, 10, 0)) == "auto"
+        assert sphinx_parallel_jobs((3, 13, 5)) == "auto"
+
+    def test_sphinx_parallel_jobs_serial_on_314_plus(self):
+        """3.14+ flipped multiprocessing to forkserver, which can't pickle
+        Sphinx's parallel ParallelTasks closures -> force a serial build."""
+        assert sphinx_parallel_jobs((3, 14, 0)) == "1"
+        assert sphinx_parallel_jobs((3, 15, 1)) == "1"
 
 
 # ── fjson parsing tests (INGR-C-04) ──


### PR DESCRIPTION
## Problem

The **Slow E2E** workflow's **Python 3.14** job fails during \`build-index\`:

\`\`\`
_pickle.PicklingError: Can't pickle local object
  <function Builder._read_parallel.<locals>.merge at 0x...>
  ... when serializing sphinx.util.parallel.ParallelTasks ...
  File ".../python3.14/multiprocessing/reduction.py", line 60, in dump
\`\`\`

It fires on the very first docs version (3.10), because the unpicklable object is in Sphinx itself, not any docs version. The 3.13 job passes.

## Root cause

**Python 3.14 changed the default \`multiprocessing\` start method on POSIX from \`fork\` to \`forkserver\`.** \`forkserver\`/\`spawn\` pickle the work handed to child processes; \`fork\` does not. Sphinx's parallel build (\`-j auto\`) passes a \`ParallelTasks\` object holding a local closure (\`Builder._read_parallel.<locals>.merge\`) that can't be pickled — so \`-j auto\` breaks on 3.14, while 3.13-and-earlier (still \`fork\`) build fine.

Not a v0.2.0 regression — \`-j auto\` is long-standing and untouched by 0.2.0; it surfaced because 3.14's default flipped. The published v0.2.0 server runtime is unaffected (this is the offline index-build path only).

## Fix

Add \`sphinx_parallel_jobs(version_info)\` → \`"1"\` on \`>= (3, 14)\`, else \`"auto"\`, and use it in \`build_sphinx_json_command\`. The Sphinx venv is created from the current interpreter (\`venv.create\`), so \`sys.version_info\` is the correct signal. Keeps parallel speed on 3.13/earlier; serial (correct, slightly slower) on 3.14+.

- Production change is one helper + one call site; server runtime untouched.
- Chosen over "serial always" (would slow every build) and "force fork" (deprecated/brittle).

## Tests

- \`test_sphinx_parallel_jobs_auto_before_314\` — 3.10/3.13 → \`"auto"\`
- \`test_sphinx_parallel_jobs_serial_on_314_plus\` — 3.14/3.15 → \`"1"\`
- Existing command test updated to be runtime-agnostic.
- Full suite **298 passed**, ruff clean, pyright 0 errors.

Ships in **0.2.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)