### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `python-docs-mcp-server` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] — 2026-05-29
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python-docs-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 description = "The canonical Python stdlib oracle for AI coding agents — exact symbols, exact sections, exact versions, offline, always free, always MIT, token-frugal."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/ayhammouda/python-docs-mcp-server",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "python-docs-mcp-server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "python-docs-mcp-server"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release prep: v0.2.1

Patch release for the **Python 3.14 `build-index` fix** (#44).

### What's in 0.2.1
- **Fixed** — \`build-index\` on Python 3.14: Sphinx's parallel build (\`-j auto\`) raised \`_pickle.PicklingError\` because 3.14 flipped the default \`multiprocessing\` start method to \`forkserver\`. The builder now uses a serial build (\`-j 1\`) on 3.14+, keeping the parallel path on \`fork\`-default interpreters (3.13 and earlier). Server runtime unchanged.

### Version sync
All four version-bearing files agree on \`0.2.1\` (\`pyproject.toml\`, \`server.json\` ×2, \`uv.lock\`).

### Verification
- Full suite **298 passed**, ruff clean, pyright 0 errors.
- **Slow E2E re-run on main (post-#44): 3.13 and 3.14 `build-index` both ✅** — the definitive proof the fix works end-to-end.

### After merge (not done here)
Per \`.github/RELEASE.md\`: tag \`v0.2.1\` from \`main\` → release workflow runs \`build → publish (PyPI) → publish-mcp-registry → github-release\`. Tagging is left to a maintainer (triggers the irreversible PyPI publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Released version 0.2.1 with updated release documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->