### PR TITLE
docs: refresh six-tool public surface

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -51,6 +51,7 @@ Replace `X.Y.Z` below with the version you are releasing (e.g. `0.1.7`). Complet
   ```
   Must report `✅ server.json is valid`. If validation fails, shorten `server.json` `description` on `main` before tagging (the `pyproject.toml` description is unbounded by this constraint and can stay longer).
 - [ ] Integration tests from `.github/INTEGRATION-TEST.md` are complete and signed off
+- [ ] Refresh README `## Tools`, `glama.json`, and registry/version badges to match the current tool surface.
 - [ ] `Doctor` subcommand passes:
   ```bash
   uv run python-docs-mcp-server doctor

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![CodeQL](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/codeql.yml/badge.svg)](https://github.com/ayhammouda/python-docs-mcp-server/actions/workflows/codeql.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/ayhammouda/python-docs-mcp-server/badge)](https://scorecard.dev/viewer/?uri=github.com/ayhammouda/python-docs-mcp-server)
 [![python-docs-mcp-server MCP server](https://glama.ai/mcp/servers/ayhammouda/python-docs-mcp-server/badges/score.svg)](https://glama.ai/mcp/servers/ayhammouda/python-docs-mcp-server)
-[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-v0.1.4-0f766e)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ayhammouda%2Fpython-docs-mcp-server)
+[![MCP Registry](https://img.shields.io/badge/MCP%20Registry-latest-0f766e)](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.ayhammouda%2Fpython-docs-mcp-server)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%2B-blue)](https://www.python.org/)
 [![No API Keys](https://img.shields.io/badge/API%20keys-none-success)](#why-use-it)

--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "description": "For AI coding agents writing Python: the canonical Python stdlib oracle. Exact symbols, exact sections, exact versions — offline, always free, always MIT, token-frugal.",
+  "description": "For AI coding agents writing Python: six read-only tools for canonical Python stdlib lookup, retrieval, local version detection, and version comparison.",
   "maintainers": [
     "ayhammouda"
   ]

--- a/glama.json
+++ b/glama.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://glama.ai/mcp/schemas/server.json",
-  "description": "For AI coding agents writing Python: six read-only tools for canonical Python stdlib lookup, retrieval, local version detection, and version comparison.",
+  "description": "For AI coding agents writing Python: six read-only tools for canonical Python stdlib lookup, retrieval, package documentation discovery, version listing, local version detection, and version comparison.",
   "maintainers": [
     "ayhammouda"
   ]


### PR DESCRIPTION
## Summary
- Refresh the README registry badge so it no longer advertises stale v0.1.4.
- Keep Glama metadata aligned with the six-tool MCP surface.
- Add the release checklist line for refreshing public tool-surface docs and badges.

## Validation
- [x] `uv run ruff check src/ tests/`
- [x] `uv run pyright src/`
- [x] `uv run pytest --tb=short -q`
- [x] `uv run python-docs-mcp-server doctor`
- [x] `uv run pytest tests/test_packaging.py -q`

## Why this triggered human review
Touches CODEOWNERS-owned brand/release docs (`README.md`, `.github/RELEASE.md`); opened for review, not auto-merge.

Closes #47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated tool descriptions to reflect available capabilities
  * Refreshed registry and version information

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ayhammouda/python-docs-mcp-server/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->