### PR TITLE
chore(release): v0.3.1 — checked-in .mcp.json project config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "python-docs": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["python-docs-mcp-server"]
+    }
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to `python-docs-mcp-server` are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] — 2026-06-01
+
+### Added
+
+- Added a checked-in `.mcp.json` project configuration for MCP clients that
+  support project-scoped server config. It starts the published server with
+  `uvx python-docs-mcp-server`.
+
+### Changed
+
+- Bumped package and MCP Registry metadata to `0.3.1`.
+
 ## [0.3.0] — 2026-05-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -111,6 +111,26 @@ cache. It can take several minutes.
 
 ## Configure your MCP client
 
+### Claude Code
+
+This repository includes a project-scoped `.mcp.json` for clients that support
+checked-in MCP server configuration. It points at the published package:
+
+```json
+{
+  "mcpServers": {
+    "python-docs": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["python-docs-mcp-server"]
+    }
+  }
+}
+```
+
+Build the local documentation index with the first-run command above before
+expecting docs queries to return corpus-backed results.
+
 ### Claude Desktop
 
 Add this to your Claude Desktop configuration file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "python-docs-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 description = "The canonical Python stdlib oracle for AI coding agents — exact symbols, exact sections, exact versions, offline, always free, always MIT, token-frugal."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/ayhammouda/python-docs-mcp-server",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "python-docs-mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -541,7 +541,7 @@ wheels = [
 
 [[package]]
 name = "python-docs-mcp-server"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## v0.3.1 — checked-in `.mcp.json` project config

Adds a project-scoped `.mcp.json` so MCP clients that support checked-in server
configuration start the published server with `uvx python-docs-mcp-server`,
documents the Claude Code project config in the README, and bumps package + MCP
Registry metadata to `0.3.1`.

### Changes
- Add `.mcp.json` (`stdio`, `uvx python-docs-mcp-server`)
- README: new `### Claude Code` config section
- Bump `pyproject.toml`, `server.json`, `uv.lock` to `0.3.1`
- CHANGELOG: `[0.3.1]` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)